### PR TITLE
Use single JsonSerializerOptions to fix dotnet 8

### DIFF
--- a/RetakesPlugin/Modules/Configs/MapConfig.cs
+++ b/RetakesPlugin/Modules/Configs/MapConfig.cs
@@ -29,7 +29,7 @@ public class MapConfig
             }
 
             var jsonData = File.ReadAllText(_mapConfigPath);
-            _mapConfigData = JsonSerializer.Deserialize<MapConfigData>(jsonData);
+            _mapConfigData = JsonSerializer.Deserialize<MapConfigData>(jsonData, Helpers.JsonSerializerOptions);
 
             // TODO: Implement validation to make sure the config is valid / has enough spawns.
             // if (_mapConfigData!.Spawns == null || _mapConfigData.Spawns.Count < 0)
@@ -119,10 +119,7 @@ public class MapConfig
 
     private void Save()
     {
-        var jsonString = JsonSerializer.Serialize(GetSanitisedMapConfigData(), new JsonSerializerOptions
-        {
-            WriteIndented = true
-        });
+        var jsonString = JsonSerializer.Serialize(GetSanitisedMapConfigData(), Helpers.JsonSerializerOptions);
 
         try
         {

--- a/RetakesPlugin/Modules/Configs/RetakesConfig.cs
+++ b/RetakesPlugin/Modules/Configs/RetakesConfig.cs
@@ -25,7 +25,7 @@ public class RetakesConfig
             }
 
             var jsonData = File.ReadAllText(_retakesConfigPath);
-            RetakesConfigData = JsonSerializer.Deserialize<RetakesConfigData>(jsonData);
+            RetakesConfigData = JsonSerializer.Deserialize<RetakesConfigData>(jsonData, Helpers.JsonSerializerOptions);
 
             if (RetakesConfigData == null)
             {
@@ -54,10 +54,7 @@ public class RetakesConfig
 
     private void Save()
     {
-        var jsonString = JsonSerializer.Serialize(RetakesConfigData, new JsonSerializerOptions
-        {
-            WriteIndented = true
-        });
+        var jsonString = JsonSerializer.Serialize(RetakesConfigData, Helpers.JsonSerializerOptions);
 
         try
         {

--- a/RetakesPlugin/Modules/Helpers.cs
+++ b/RetakesPlugin/Modules/Helpers.cs
@@ -1,10 +1,12 @@
 using System.Drawing;
 using System.Text;
+using System.Text.Json;
 using CounterStrikeSharp.API;
 using CounterStrikeSharp.API.Core;
 using CounterStrikeSharp.API.Modules.Entities.Constants;
 using CounterStrikeSharp.API.Modules.Utils;
 using RetakesPlugin.Modules.Configs;
+using RetakesPlugin.Modules.Configs.JsonConverters;
 using RetakesPluginShared.Enums;
 
 namespace RetakesPlugin.Modules;
@@ -12,6 +14,15 @@ namespace RetakesPlugin.Modules;
 public static class Helpers
 {
     internal static readonly Random Random = new();
+    internal static readonly JsonSerializerOptions JsonSerializerOptions = new()
+    {
+        WriteIndented = true,
+        Converters =
+        {
+            new VectorJsonConverter(),
+            new QAngleJsonConverter()
+        }
+    };
 
     public static bool IsValidPlayer(CCSPlayerController? player)
     {


### PR DESCRIPTION
This fixes the JSON serialization/deserialization on .NET 8, as the attribute is broken due to [a breaking change](https://learn.microsoft.com/en-us/dotnet/core/compatibility/serialization/8.0/metadata-resolving)