### PR TITLE
fix bad logic with fallback announcer config option

### DIFF
--- a/RetakesPlugin/Modules/Configs/RetakesConfigData.cs
+++ b/RetakesPlugin/Modules/Configs/RetakesConfigData.cs
@@ -18,5 +18,5 @@ public class RetakesConfigData
     public string QueuePriorityFlag { get; set; } = "@css/vip";
     public bool IsDebugMode { get; set; } = false;
     public bool ShouldForceEvenTeamsWhenPlayerCountIsMultipleOf10 { get; set; } = true;
-    public bool EnableFallbackBombsiteAnnouncement { get; set; }
+    public bool? EnableFallbackBombsiteAnnouncement { get; set; }
 }

--- a/RetakesPlugin/Modules/Configs/RetakesConfigData.cs
+++ b/RetakesPlugin/Modules/Configs/RetakesConfigData.cs
@@ -18,5 +18,5 @@ public class RetakesConfigData
     public string QueuePriorityFlag { get; set; } = "@css/vip";
     public bool IsDebugMode { get; set; } = false;
     public bool ShouldForceEvenTeamsWhenPlayerCountIsMultipleOf10 { get; set; } = true;
-    public bool? EnableFallbackBombsiteAnnouncement { get; set; }
+    public bool EnableFallbackBombsiteAnnouncement { get; set; } = true;
 }

--- a/RetakesPlugin/RetakesPlugin.cs
+++ b/RetakesPlugin/RetakesPlugin.cs
@@ -629,7 +629,8 @@ public class RetakesPlugin : BasePlugin
 
         _planter = _spawnManager.HandleRoundSpawns(_currentBombsite, _gameManager.QueueManager.ActivePlayers);
 
-        if (_retakesConfig?.RetakesConfigData?.EnableFallbackBombsiteAnnouncement is true)
+        if (!RetakesConfig.IsLoaded(_retakesConfig) ||
+            _retakesConfig!.RetakesConfigData!.EnableFallbackBombsiteAnnouncement)
         {
             AnnounceBombsite(_currentBombsite);
         }

--- a/RetakesPlugin/RetakesPlugin.cs
+++ b/RetakesPlugin/RetakesPlugin.cs
@@ -629,7 +629,7 @@ public class RetakesPlugin : BasePlugin
 
         _planter = _spawnManager.HandleRoundSpawns(_currentBombsite, _gameManager.QueueManager.ActivePlayers);
 
-        if (_retakesConfig?.RetakesConfigData?.EnableFallbackBombsiteAnnouncement is true or null)
+        if (_retakesConfig?.RetakesConfigData?.EnableFallbackBombsiteAnnouncement is true)
         {
             AnnounceBombsite(_currentBombsite);
         }


### PR DESCRIPTION
This code [here](https://github.com/B3none/cs2-retakes/blob/95e144b6deba61043cc084c4573c1d3b56864e7d/RetakesPlugin/RetakesPlugin.cs#L632) is responsible for showing bombsite announcements, and it checks if it is null in the case where it is not in the config file. However, as it is not nullable, it will not use the fallback announcer when not in the config. I have made it default to true, to combat this as people expect this to be enabled by default.