### PR TITLE
Fix scrambling bugs #104

### DIFF
--- a/RetakesPlugin/RetakesPlugin.cs
+++ b/RetakesPlugin/RetakesPlugin.cs
@@ -20,7 +20,7 @@ namespace RetakesPlugin;
 [MinimumApiVersion(201)]
 public class RetakesPlugin : BasePlugin
 {
-    private const string Version = "2.0.1";
+    private const string Version = "2.0.2";
 
     #region Plugin info
     public override string ModuleName => "Retakes Plugin";

--- a/RetakesPlugin/RetakesPlugin.cs
+++ b/RetakesPlugin/RetakesPlugin.cs
@@ -557,23 +557,9 @@ public class RetakesPlugin : BasePlugin
         _gameManager.QueueManager.DebugQueues(false);
         Helpers.Debug($"Updated queues.");
 
-        // Handle team swaps during round pre-start.
-        switch (_lastRoundWinner)
-        {
-            case CsTeam.CounterTerrorist:
-                Helpers.Debug($"Calling CounterTerroristRoundWin()");
-                _gameManager.CounterTerroristRoundWin();
-                Helpers.Debug($"CounterTerroristRoundWin call complete");
-                break;
-
-            case CsTeam.Terrorist:
-                Helpers.Debug($"Calling TerroristRoundWin()");
-                _gameManager.TerroristRoundWin();
-                Helpers.Debug($"TerroristRoundWin call complete");
-                break;
-        }
-
-        _gameManager.BalanceTeams();
+        Helpers.Debug($"Calling GameManager.OnRoundPreStart({_lastRoundWinner})");
+        _gameManager.OnRoundPreStart(_lastRoundWinner);
+        Helpers.Debug($"GameManager.OnRoundPreStart call complete");
 
         // Set round teams to prevent team changes mid round
         _gameManager.QueueManager.SetRoundTeams();


### PR DESCRIPTION
- Ensures ScrambleTeams() is not automatically called if IsScrambleEnabled is False
- Fix almost scamble message to take roundsToScramble configuration into account.
- Fix admin team scramble only done on T-win and not if more than 3 rounds in a row have been won.