### PR TITLE
Remove player from game and queue if they are moved to spectator

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ When the plugin is first loaded it will create a `retakes_config.json` file in t
 | IsDebugMode                                       | Whether to enable debug output to the server console or not.                                                                                    | false      | false      | true       |
 | ShouldForceEvenTeamsWhenPlayerCountIsMultipleOf10 | Whether to force even teams when the active players is a multiple of 10 or not. (this means you will get 5v5 @ 10 players / 10v10 @ 20 players) | true       | false      | true       |
 | EnableFallbackBombsiteAnnouncement                | Whether to enable the fallback bombsite announcement.                                                                                           | true       | false      | true       |
-| RemoveSpectators                                  | When a player is moved to spectators, remove them from all retake queues. Ensures that AFK plugins work as expected.                            | false      |    false      | true       |
+| ShouldRemoveSpectators                            | When a player is moved to spectators, remove them from all retake queues. Ensures that AFK plugins work as expected.                            | false      |    false      | true       |
 
 ## Commands
 | Command         | Arguments                         | Description                                                          | Permissions |

--- a/README.md
+++ b/README.md
@@ -2,17 +2,14 @@
 ![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/b3none/cs2-retakes/plugin-build.yml?branch=master&style=flat-square&label=Latest%20Build)
 
 # CS2 Retakes
-
 CS2 implementation of retakes written in C# for CounterStrikeSharp. Based on the version for CS:GO by Splewis.
 
 ## Share the love
-
 If you appreciate the project then please take the time to star the repository üôè
 
 ![Star us](https://github.com/b3none/gdprconsent/raw/development/.github/README_ASSETS/star_us.png)
 
 ## Features / Roadmap
-
 - [x] Bombsite selection
 - [x] Per map configurations
 - [x] Ability to add spawns
@@ -33,28 +30,22 @@ If you appreciate the project then please take the time to star the repository 
 - [x] Add a release zip file without spawns too
 
 ## Installation
-
 - Download the zip file from the [latest release](https://github.com/B3none/cs2-retakes/releases), and extract the contents into your `counterstrikesharp/plugins` directory.
 - Download the [shared plugin zip file](https://github.com/B3none/cs2-retakes/releases/download/2.0.0/cs2-retakes-plugin-shared-2.0.0.zip) and put it into your `counterstrikesharp/shared` directory.
 
 ## Recommendations
-
 I also recommend installing these plugins for an improved player experience
-
-- Instadefuse: <https://github.com/B3none/cs2-instadefuse>
-- Clutch Announce: <https://github.com/B3none/cs2-clutch-announce>
-- Instaplant (if not using autoplant): <https://github.com/B3none/cs2-instaplant>
+- Instadefuse: https://github.com/B3none/cs2-instadefuse
+- Clutch Announce: https://github.com/B3none/cs2-clutch-announce
+- Instaplant (if not using autoplant): https://github.com/B3none/cs2-instaplant
 
 ## Allocators
-
 Although this plugin comes with it's own weapon allocation system, I would recommend using **one** of the following plugins for a better experience:
-
-- Yoni's Allocator: <https://github.com/yonilerner/cs2-retakes-allocator>
-- NokkviReyr's Allocator: <https://github.com/nokkvireyr/kps-allocator>
-- Ravid's Allocator: <https://github.com/Ravid-A/cs2-retakes-weapon-allocator>
+- Yoni's Allocator: https://github.com/yonilerner/cs2-retakes-allocator
+- NokkviReyr's Allocator: https://github.com/nokkvireyr/kps-allocator
+- Ravid's Allocator: https://github.com/Ravid-A/cs2-retakes-weapon-allocator
 
 ## Configuration
-
 When the plugin is first loaded it will create a `retakes_config.json` file in the plugin directory. This file contains all of the configuration options for the plugin:
 
 | Config                                            | Description                                                                                                                                     | Default    | Min        | Max        |
@@ -73,10 +64,9 @@ When the plugin is first loaded it will create a `retakes_config.json` file in t
 | IsDebugMode                                       | Whether to enable debug output to the server console or not.                                                                                    | false      | false      | true       |
 | ShouldForceEvenTeamsWhenPlayerCountIsMultipleOf10 | Whether to force even teams when the active players is a multiple of 10 or not. (this means you will get 5v5 @ 10 players / 10v10 @ 20 players) | true       | false      | true       |
 | EnableFallbackBombsiteAnnouncement                | Whether to enable the fallback bombsite announcement.                                                                                           | true       | false      | true       |
-| RemoveSpectators                                 | When a player is moved to spectators, remove them from all retake queues. Ensures that AFK plugins work as expected.                                                         | true       | false      | true       |
+| RemoveSpectators                                  | When a player is moved to spectators, remove them from all retake queues. Ensures that AFK plugins work as expected.                            | false      |    false      | true       |
 
 ## Commands
-
 | Command         | Arguments                         | Description                                                          | Permissions |
 |-----------------|-----------------------------------|----------------------------------------------------------------------|-------------|
 | !showspawns     | <A / B>                           | Show the spawns for the specified bombsite.                          | @css/root   |
@@ -89,11 +79,9 @@ When the plugin is first loaded it will create a `retakes_config.json` file in t
 | css_debugqueues |                                   | **SERVER ONLY** Shows the current queue state in the server console. |             |
 
 ## Stay up to date
-
 Subscribe to **release** notifications and stay up to date with the latest features and patches:
 
 ![image](https://github.com/B3none/cs2-retakes/assets/24966460/e288a882-0f1f-4e8c-b67f-e4c066af34ea)
 
 ## Credits
-
 This was inspired by the [CS:GO Retakes project](https://github.com/splewis/csgo-retakes) written by [splewis](https://github.com/splewis).

--- a/README.md
+++ b/README.md
@@ -2,14 +2,17 @@
 ![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/b3none/cs2-retakes/plugin-build.yml?branch=master&style=flat-square&label=Latest%20Build)
 
 # CS2 Retakes
+
 CS2 implementation of retakes written in C# for CounterStrikeSharp. Based on the version for CS:GO by Splewis.
 
 ## Share the love
+
 If you appreciate the project then please take the time to star the repository üôè
 
 ![Star us](https://github.com/b3none/gdprconsent/raw/development/.github/README_ASSETS/star_us.png)
 
 ## Features / Roadmap
+
 - [x] Bombsite selection
 - [x] Per map configurations
 - [x] Ability to add spawns
@@ -30,22 +33,28 @@ If you appreciate the project then please take the time to star the repository 
 - [x] Add a release zip file without spawns too
 
 ## Installation
+
 - Download the zip file from the [latest release](https://github.com/B3none/cs2-retakes/releases), and extract the contents into your `counterstrikesharp/plugins` directory.
 - Download the [shared plugin zip file](https://github.com/B3none/cs2-retakes/releases/download/2.0.0/cs2-retakes-plugin-shared-2.0.0.zip) and put it into your `counterstrikesharp/shared` directory.
 
 ## Recommendations
+
 I also recommend installing these plugins for an improved player experience
-- Instadefuse: https://github.com/B3none/cs2-instadefuse
-- Clutch Announce: https://github.com/B3none/cs2-clutch-announce
-- Instaplant (if not using autoplant): https://github.com/B3none/cs2-instaplant
+
+- Instadefuse: <https://github.com/B3none/cs2-instadefuse>
+- Clutch Announce: <https://github.com/B3none/cs2-clutch-announce>
+- Instaplant (if not using autoplant): <https://github.com/B3none/cs2-instaplant>
 
 ## Allocators
+
 Although this plugin comes with it's own weapon allocation system, I would recommend using **one** of the following plugins for a better experience:
-- Yoni's Allocator: https://github.com/yonilerner/cs2-retakes-allocator
-- NokkviReyr's Allocator: https://github.com/nokkvireyr/kps-allocator
-- Ravid's Allocator: https://github.com/Ravid-A/cs2-retakes-weapon-allocator
+
+- Yoni's Allocator: <https://github.com/yonilerner/cs2-retakes-allocator>
+- NokkviReyr's Allocator: <https://github.com/nokkvireyr/kps-allocator>
+- Ravid's Allocator: <https://github.com/Ravid-A/cs2-retakes-weapon-allocator>
 
 ## Configuration
+
 When the plugin is first loaded it will create a `retakes_config.json` file in the plugin directory. This file contains all of the configuration options for the plugin:
 
 | Config                                            | Description                                                                                                                                     | Default    | Min        | Max        |
@@ -64,8 +73,10 @@ When the plugin is first loaded it will create a `retakes_config.json` file in t
 | IsDebugMode                                       | Whether to enable debug output to the server console or not.                                                                                    | false      | false      | true       |
 | ShouldForceEvenTeamsWhenPlayerCountIsMultipleOf10 | Whether to force even teams when the active players is a multiple of 10 or not. (this means you will get 5v5 @ 10 players / 10v10 @ 20 players) | true       | false      | true       |
 | EnableFallbackBombsiteAnnouncement                | Whether to enable the fallback bombsite announcement.                                                                                           | true       | false      | true       |
+| RemoveSpectators                                 | When a player is moved to spectators, remove them from all retake queues. Ensures that AFK plugins work as expected.                                                         | true       | false      | true       |
 
 ## Commands
+
 | Command         | Arguments                         | Description                                                          | Permissions |
 |-----------------|-----------------------------------|----------------------------------------------------------------------|-------------|
 | !showspawns     | <A / B>                           | Show the spawns for the specified bombsite.                          | @css/root   |
@@ -78,9 +89,11 @@ When the plugin is first loaded it will create a `retakes_config.json` file in t
 | css_debugqueues |                                   | **SERVER ONLY** Shows the current queue state in the server console. |             |
 
 ## Stay up to date
+
 Subscribe to **release** notifications and stay up to date with the latest features and patches:
 
 ![image](https://github.com/B3none/cs2-retakes/assets/24966460/e288a882-0f1f-4e8c-b67f-e4c066af34ea)
 
 ## Credits
+
 This was inspired by the [CS:GO Retakes project](https://github.com/splewis/csgo-retakes) written by [splewis](https://github.com/splewis).

--- a/RetakesPlugin/Modules/Configs/RetakesConfigData.cs
+++ b/RetakesPlugin/Modules/Configs/RetakesConfigData.cs
@@ -2,7 +2,7 @@
 
 public class RetakesConfigData
 {
-    public static int CurrentVersion = 8;
+    public static int CurrentVersion = 9;
 
     public int Version { get; set; } = CurrentVersion;
     public int MaxPlayers { get; set; } = 9;
@@ -19,4 +19,6 @@ public class RetakesConfigData
     public bool IsDebugMode { get; set; } = false;
     public bool ShouldForceEvenTeamsWhenPlayerCountIsMultipleOf10 { get; set; } = true;
     public bool EnableFallbackBombsiteAnnouncement { get; set; } = true;
+    public bool RemoveSpectators { get; set; } = true;
+
 }

--- a/RetakesPlugin/Modules/Configs/RetakesConfigData.cs
+++ b/RetakesPlugin/Modules/Configs/RetakesConfigData.cs
@@ -19,6 +19,5 @@ public class RetakesConfigData
     public bool IsDebugMode { get; set; } = false;
     public bool ShouldForceEvenTeamsWhenPlayerCountIsMultipleOf10 { get; set; } = true;
     public bool EnableFallbackBombsiteAnnouncement { get; set; } = true;
-    public bool RemoveSpectators { get; set; } = true;
-
+    public bool ShouldRemoveSpectators { get; set; } = true;
 }

--- a/RetakesPlugin/Modules/Managers/GameManager.cs
+++ b/RetakesPlugin/Modules/Managers/GameManager.cs
@@ -1,7 +1,6 @@
 ﻿using CounterStrikeSharp.API;
 using CounterStrikeSharp.API.Core;
 using CounterStrikeSharp.API.Modules.Utils;
-using Serilog.Debugging;
 
 namespace RetakesPlugin.Modules.Managers;
 
@@ -12,7 +11,7 @@ public class GameManager
     public readonly QueueManager QueueManager;
     private readonly int _consecutiveRoundWinsToScramble;
     private readonly bool _isScrambleEnabled;
-    private readonly bool _RemoveSpectatorsEnabled;
+    private readonly bool _removeSpectatorsEnabled;
     public const int ScoreForKill = 50;
     public const int ScoreForAssist = 25;
     public const int ScoreForDefuse = 50;
@@ -23,7 +22,7 @@ public class GameManager
         QueueManager = queueManager;
         _consecutiveRoundWinsToScramble = roundsToScramble ?? 5;
         _isScrambleEnabled = isScrambleEnabled ?? true;
-        _RemoveSpectatorsEnabled = RemoveSpectatorsEnabled ?? true;
+        _removeSpectatorsEnabled = RemoveSpectatorsEnabled ?? false;
     }
 
     private bool _scrambleNextRound;
@@ -250,7 +249,7 @@ public class GameManager
 
     public HookResult RemoveSpectators(EventPlayerTeam @event, HashSet<CCSPlayerController> _hasMutedVoices)
     {
-        if (_RemoveSpectatorsEnabled)
+        if (_removeSpectatorsEnabled)
         {
             CCSPlayerController? player = @event.Userid;
 

--- a/RetakesPlugin/RetakesPlugin.cs
+++ b/RetakesPlugin/RetakesPlugin.cs
@@ -831,8 +831,12 @@ public class RetakesPlugin : BasePlugin
 
         if (team == (int)CsTeam.Spectator)
         {
-            _gameManager.QueueManager.RemovePlayerFromQueues(player);
-            _hasMutedVoices.Remove(player);
+            // Ensure player is active ingame.
+            if (_gameManager.QueueManager.ActivePlayers.Contains(player))
+            {
+                _gameManager.QueueManager.RemovePlayerFromQueues(player);
+                _hasMutedVoices.Remove(player);
+            }
         }
         return HookResult.Continue;
     }

--- a/RetakesPlugin/RetakesPlugin.cs
+++ b/RetakesPlugin/RetakesPlugin.cs
@@ -487,7 +487,8 @@ public class RetakesPlugin : BasePlugin
                 _retakesConfig?.RetakesConfigData?.ShouldForceEvenTeamsWhenPlayerCountIsMultipleOf10
             ),
             _retakesConfig?.RetakesConfigData?.RoundsToScramble,
-            _retakesConfig?.RetakesConfigData?.IsScrambleEnabled
+            _retakesConfig?.RetakesConfigData?.IsScrambleEnabled,
+            _retakesConfig?.RetakesConfigData?.RemoveSpectators
         );
 
         _breakerManager = new BreakerManager(
@@ -815,30 +816,12 @@ public class RetakesPlugin : BasePlugin
         // Ensure all team join events are silent.
         @event.Silent = true;
 
-        CCSPlayerController? player = @event.Userid;
-
         if (_gameManager == null)
         {
             Helpers.Debug($"Game manager not loaded.");
             return HookResult.Continue;
         }
-
-        if (!Helpers.IsValidPlayer(player))
-        {
-            return HookResult.Continue;
-        }
-        int team = @event.Team;
-
-        if (team == (int)CsTeam.Spectator)
-        {
-            // Ensure player is active ingame.
-            if (_gameManager.QueueManager.ActivePlayers.Contains(player))
-            {
-                _gameManager.QueueManager.RemovePlayerFromQueues(player);
-                _hasMutedVoices.Remove(player);
-            }
-        }
-        return HookResult.Continue;
+        return _gameManager.RemoveSpectators(@event, _hasMutedVoices);
     }
 
     private HookResult OnCommandJoinTeam(CCSPlayerController? player, CommandInfo commandInfo)

--- a/RetakesPlugin/RetakesPlugin.cs
+++ b/RetakesPlugin/RetakesPlugin.cs
@@ -815,6 +815,25 @@ public class RetakesPlugin : BasePlugin
         // Ensure all team join events are silent.
         @event.Silent = true;
 
+        CCSPlayerController? player = @event.Userid;
+
+        if (_gameManager == null)
+        {
+            Helpers.Debug($"Game manager not loaded.");
+            return HookResult.Continue;
+        }
+
+        if (!Helpers.IsValidPlayer(player))
+        {
+            return HookResult.Continue;
+        }
+        int team = @event.Team;
+
+        if (team == (int)CsTeam.Spectator)
+        {
+            _gameManager.QueueManager.RemovePlayerFromQueues(player);
+            _hasMutedVoices.Remove(player);
+        }
         return HookResult.Continue;
     }
 

--- a/RetakesPlugin/RetakesPlugin.cs
+++ b/RetakesPlugin/RetakesPlugin.cs
@@ -20,7 +20,7 @@ namespace RetakesPlugin;
 [MinimumApiVersion(220)]
 public class RetakesPlugin : BasePlugin
 {
-    private const string Version = "2.0.4";
+    private const string Version = "2.0.5";
 
     #region Plugin info
     public override string ModuleName => "Retakes Plugin";
@@ -488,7 +488,7 @@ public class RetakesPlugin : BasePlugin
             ),
             _retakesConfig?.RetakesConfigData?.RoundsToScramble,
             _retakesConfig?.RetakesConfigData?.IsScrambleEnabled,
-            _retakesConfig?.RetakesConfigData?.RemoveSpectators
+            _retakesConfig?.RetakesConfigData?.ShouldRemoveSpectators
         );
 
         _breakerManager = new BreakerManager(
@@ -821,6 +821,7 @@ public class RetakesPlugin : BasePlugin
             Helpers.Debug($"Game manager not loaded.");
             return HookResult.Continue;
         }
+
         return _gameManager.RemoveSpectators(@event, _hasMutedVoices);
     }
 


### PR DESCRIPTION
I made these changes to ensure it is compatible with a plugin such as [AFKManager](https://github.com/NiGHT757/AFKManager) which only moves a player to spectator and has no way of knowing how to dequeue a player. Without this change players will be moved to spectator and then moved back into a team and actually never get kicked if you do not use an overly aggressive afk kick of 15 seconds without spectator. I made this for personal use but thought it might be benefit others 