### PR TITLE
Update de_train.json

### DIFF
--- a/RetakesPlugin/map_config/de_train.json
+++ b/RetakesPlugin/map_config/de_train.json
@@ -225,8 +225,8 @@
       "CanBePlanter": false
     },
     {
-      "Vector": "-916.2804 1272.2365 -213.96753",
-      "QAngle": "0 19.68956 0",
+      "Vector": "419.41 1695.32 -213.96753",
+      "QAngle": "0 -159.70 0",
       "Team": 3,
       "Bombsite": 0,
       "CanBePlanter": false


### PR DESCRIPTION
Move ct spawn point for bombsite A from t spawn to alley

This spawn point limits how t can hold T main as the contact is <1 second 

Original
![{6A960A35-EFD0-42CA-8FD6-62C436D4E655}](https://github.com/user-attachments/assets/911164a7-dc1c-442e-9981-3c3ab1e0104e)

Proposed
![{35E7935D-6BB0-44B5-B8E0-F423D91E3379}](https://github.com/user-attachments/assets/085a735d-0763-4f96-ac37-901e713aedf4)

"unfairness" contact
![{7E0D9529-F865-4CF3-8BC0-2E216EAE1BD4}](https://github.com/user-attachments/assets/d0eb2ac1-5d4e-436c-974b-c8789d9f7f08)
