### PR TITLE
Allows server to execute CLIENT_AND_SERVER commands

### DIFF
--- a/RetakesPlugin/RetakesPlugin.cs
+++ b/RetakesPlugin/RetakesPlugin.cs
@@ -108,7 +108,7 @@ public class RetakesPlugin : BasePlugin
     [RequiresPermissions("@css/root")]
     public void OnCommandMapConfig(CCSPlayerController? player, CommandInfo commandInfo)
     {
-        if (!Helpers.IsValidPlayer(player))
+        if (player != null && !Helpers.IsValidPlayer(player))
         {
             return;
         }
@@ -143,7 +143,7 @@ public class RetakesPlugin : BasePlugin
     [RequiresPermissions("@css/root")]
     public void OnCommandMapConfigs(CCSPlayerController? player, CommandInfo commandInfo)
     {
-        if (player == null || !Helpers.IsValidPlayer(player))
+        if (player != null && !Helpers.IsValidPlayer(player))
         {
             return;
         }
@@ -179,7 +179,7 @@ public class RetakesPlugin : BasePlugin
     [RequiresPermissions("@css/root")]
     public void OnCommandForceBombsite(CCSPlayerController? player, CommandInfo commandInfo)
     {
-        if (!Helpers.IsValidPlayer(player))
+        if (player != null && !Helpers.IsValidPlayer(player))
         {
             return;
         }
@@ -201,7 +201,7 @@ public class RetakesPlugin : BasePlugin
     [RequiresPermissions("@css/root")]
     public void OnCommandForceBombsiteStop(CCSPlayerController? player, CommandInfo commandInfo)
     {
-        if (!Helpers.IsValidPlayer(player))
+        if (player != null && !Helpers.IsValidPlayer(player))
         {
             return;
         }
@@ -218,7 +218,7 @@ public class RetakesPlugin : BasePlugin
     [RequiresPermissions("@css/root")]
     public void OnCommandShowSpawns(CCSPlayerController? player, CommandInfo commandInfo)
     {
-        if (!Helpers.IsValidPlayer(player))
+        if (player != null && !Helpers.IsValidPlayer(player))
         {
             return;
         }


### PR DESCRIPTION
Currently, even though some commands are marked as `CLIENT_AND_SERVER`, because of the `IsValidPlayer` check, only the client is able to execute them.

With my changes, the server is now able to execute these commands, too.

As a real usage example, this change allows to circumvent the issue with loading/unloading Retakes Plugin on demand. Sure, this is might not be a "proper" fix for this issue, but it's the one that works for me, and it also fixes a seeming inconsistency in the code.