### PR TITLE
fix: allow team joining during warmup (closes #157)

### DIFF
--- a/RetakesPlugin/Modules/Managers/QueueManager.cs
+++ b/RetakesPlugin/Modules/Managers/QueueManager.cs
@@ -72,9 +72,9 @@ public class QueueManager
                 return HookResult.Continue;
             }
 
-            if (!_shouldPreventTeamChangesMidRound)
+            if (!_shouldPreventTeamChangesMidRound || Helpers.GetGameRules().WarmupPeriod)
             {
-                Helpers.Debug($"[{player.PlayerName}] Preventing team changes mid round is disabled, allowing team change.");
+                Helpers.Debug($"[{player.PlayerName}] Preventing team changes mid round is disabled or warmup is active, allowing team change.");
                 return HookResult.Continue;
             }
 

--- a/RetakesPlugin/RetakesPlugin.cs
+++ b/RetakesPlugin/RetakesPlugin.cs
@@ -20,7 +20,7 @@ namespace RetakesPlugin;
 [MinimumApiVersion(220)]
 public class RetakesPlugin : BasePlugin
 {
-    private const string Version = "2.1.0";
+    private const string Version = "2.1.1";
 
     #region Plugin info
     public override string ModuleName => "Retakes Plugin";


### PR DESCRIPTION
This PR addresses issue [#157](https://github.com/B3none/cs2-retakes/issues/157), where players cannot join a team at the start of the game.

**Cause**:
The `_shouldPreventTeamChangesMidRound` flag was being treated as `true` even during warmup, which unintentionally blocked team switching before the actual match began.

**Fix**:
We now explicitly treat `_shouldPreventTeamChangesMidRound` as `false` during warmup, allowing players to change teams freely until the round officially starts.