### PR TITLE
Update to CounterStrikeSharp v1.0.335 + add `de_ancient_night` config

### DIFF
--- a/RetakesPlugin/RetakesPlugin.cs
+++ b/RetakesPlugin/RetakesPlugin.cs
@@ -17,10 +17,10 @@ using Helpers = RetakesPlugin.Modules.Helpers;
 
 namespace RetakesPlugin;
 
-[MinimumApiVersion(220)]
+[MinimumApiVersion(335)]
 public class RetakesPlugin : BasePlugin
 {
-    private const string Version = "2.1.3";
+    private const string Version = "2.1.4";
 
     #region Plugin info
     public override string ModuleName => "Retakes Plugin";

--- a/RetakesPlugin/RetakesPlugin.csproj
+++ b/RetakesPlugin/RetakesPlugin.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CounterStrikeSharp.API" Version="1.0.333" />
+    <PackageReference Include="CounterStrikeSharp.API" Version="1.0.335" />
     <PackageReference Include="Microsoft.Extensions.Localization.Abstractions" Version="9.0.8" />
     <ProjectReference Include="..\RetakesPluginShared\RetakesPluginShared.csproj" />
   </ItemGroup>

--- a/RetakesPlugin/map_config/de_ancient_night.json
+++ b/RetakesPlugin/map_config/de_ancient_night.json
@@ -1,240 +1,247 @@
 {
   "Spawns": [
     {
-      "Vector": "-1701.56 -1136.77 -21.34",
-      "QAngle": "0 92.42 0",
+      "Vector": "-1,701.56 -1,136.77 -21.34",
+      "QAngle": "0.00 92.42 0.00",
       "Team": 3,
       "Bombsite": 0,
       "CanBePlanter": false
     },
     {
-      "Vector": "-1870.92 -1094.4 -25.68",
-      "QAngle": "0 85.14 0",
+      "Vector": "-1,870.92 -1,094.40 -25.68",
+      "QAngle": "0.00 85.14 0.00",
       "Team": 3,
       "Bombsite": 0,
       "CanBePlanter": false
     },
     {
-      "Vector": "-1461.51 -1156.01 -11.22",
-      "QAngle": "0 120.34 0",
+      "Vector": "-1,461.51 -1,156.01 -11.22",
+      "QAngle": "0.00 120.34 0.00",
       "Team": 3,
       "Bombsite": 0,
       "CanBePlanter": false
     },
     {
-      "Vector": "-530.9 -562.85 34.25",
-      "QAngle": "0 126.89 0",
+      "Vector": "-530.90 -562.85 34.25",
+      "QAngle": "0.00 126.89 0.00",
       "Team": 3,
       "Bombsite": 0,
       "CanBePlanter": false
     },
     {
       "Vector": "-376.98 -589.89 33.63",
-      "QAngle": "0 140.55 0",
+      "QAngle": "0.00 140.55 0.00",
       "Team": 3,
       "Bombsite": 0,
       "CanBePlanter": false
     },
     {
       "Vector": "-492.12 78.27 128.83",
-      "QAngle": "0 -126.17 0",
+      "QAngle": "0.00 -126.17 0.00",
       "Team": 3,
       "Bombsite": 0,
       "CanBePlanter": false
     },
     {
-      "Vector": "-555.44 669 138.08",
-      "QAngle": "0 47.42 0",
+      "Vector": "-555.44 669.00 138.08",
+      "QAngle": "0.00 47.42 0.00",
       "Team": 3,
       "Bombsite": 0,
       "CanBePlanter": false
     },
     {
       "Vector": "143.56 880.04 87.49",
-      "QAngle": "0 -150.13 0",
+      "QAngle": "0.00 -150.13 0.00",
       "Team": 3,
       "Bombsite": 0,
       "CanBePlanter": false
     },
     {
-      "Vector": "14 906.11 74.03",
-      "QAngle": "0 -111.82 0",
+      "Vector": "14.00 906.11 74.03",
+      "QAngle": "0.00 -111.82 0.00",
       "Team": 3,
       "Bombsite": 0,
       "CanBePlanter": false
     },
     {
       "Vector": "-210.35 723.11 77.66",
-      "QAngle": "0 106.09 0",
+      "QAngle": "0.00 106.09 0.00",
       "Team": 3,
       "Bombsite": 0,
       "CanBePlanter": false
     },
     {
-      "Vector": "-1226.28 729.97 56.03",
-      "QAngle": "0 178.12 0",
+      "Vector": "-1,226.28 729.97 56.03",
+      "QAngle": "0.00 178.12 0.00",
       "Team": 2,
       "Bombsite": 0,
       "CanBePlanter": true
     },
     {
-      "Vector": "-1301.03 828.16 54.03",
-      "QAngle": "0 3.14 0",
+      "Vector": "-1,301.03 828.16 54.03",
+      "QAngle": "0.00 3.14 0.00",
       "Team": 2,
       "Bombsite": 0,
       "CanBePlanter": true
     },
     {
-      "Vector": "-1562.02 731.65 56.03",
-      "QAngle": "0 26.82 0",
+      "Vector": "-1,562.02 731.65 56.03",
+      "QAngle": "0.00 26.82 0.00",
       "Team": 2,
       "Bombsite": 0,
       "CanBePlanter": true
     },
     {
-      "Vector": "-1527.92 931.31 54.03",
-      "QAngle": "0 -98.86 0",
+      "Vector": "-1,527.92 931.31 54.03",
+      "QAngle": "0.00 -98.86 0.00",
       "Team": 2,
       "Bombsite": 0,
       "CanBePlanter": false
     },
     {
-      "Vector": "-1665.46 1187.97 52.03",
-      "QAngle": "0 -122.5 0",
+      "Vector": "-1,665.46 1,187.97 52.03",
+      "QAngle": "0.00 -122.50 0.00",
       "Team": 2,
       "Bombsite": 0,
       "CanBePlanter": false
     },
     {
-      "Vector": "-1466.5 1148.96 97.45",
-      "QAngle": "0 45.27 0",
+      "Vector": "-1,466.50 1,148.96 97.45",
+      "QAngle": "0.00 45.27 0.00",
       "Team": 2,
       "Bombsite": 0,
       "CanBePlanter": false
     },
     {
-      "Vector": "-178.52 1309.92 28.57",
-      "QAngle": "0 -89.77 0",
-      "Team": 3,
-      "Bombsite": 1,
-      "CanBePlanter": false
-    },
-    {
-      "Vector": "-315.99 1304.19 26.23",
-      "QAngle": "0 -72 0",
+      "Vector": "-178.52 1,309.92 28.57",
+      "QAngle": "0.00 -89.77 0.00",
       "Team": 3,
       "Bombsite": 1,
       "CanBePlanter": false
     },
     {
-      "Vector": "-439.99 1217.56 50.63",
-      "QAngle": "0 -51.58 0",
+      "Vector": "-315.99 1,304.19 26.23",
+      "QAngle": "0.00 -72.00 0.00",
+      "Team": 3,
+      "Bombsite": 1,
+      "CanBePlanter": false
+    },
+    {
+      "Vector": "-439.99 1,217.56 50.63",
+      "QAngle": "0.00 -51.58 0.00",
       "Team": 3,
       "Bombsite": 1,
       "CanBePlanter": false
     },
     {
       "Vector": "-544.63 892.36 103.54",
-      "QAngle": "0 -12.95 0",
+      "QAngle": "0.00 -12.95 0.00",
       "Team": 3,
       "Bombsite": 1,
       "CanBePlanter": false
     },
     {
-      "Vector": "797.17 4.97 131.4",
-      "QAngle": "0 -30.6 0",
+      "Vector": "-210.55 -705.51 164.03",
+      "QAngle": "0.00 -12.12 0.00",
+      "Team": 3,
+      "Bombsite": 1,
+      "CanBePlanter": false
+    },
+    {
+      "Vector": "-214.63 -813.57 164.03",
+      "QAngle": "0.00 0.42 0.00",
+      "Team": 3,
+      "Bombsite": 1,
+      "CanBePlanter": false
+    },
+    {
+      "Vector": "566.91 -808.29 108.01",
+      "QAngle": "0.00 9.49 0.00",
+      "Team": 3,
+      "Bombsite": 1,
+      "CanBePlanter": false
+    },
+    {
+      "Vector": "647.28 -627.91 93.59",
+      "QAngle": "0.00 -9.83 0.00",
+      "Team": 3,
+      "Bombsite": 1,
+      "CanBePlanter": false
+    },
+    {
+      "Vector": "1,230.87 -1,253.92 6.90",
+      "QAngle": "0.00 110.91 0.00",
+      "Team": 3,
+      "Bombsite": 1,
+      "CanBePlanter": false
+    },
+    {
+      "Vector": "944.03 -1,266.52 3.74",
+      "QAngle": "0.00 66.06 0.00",
+      "Team": 3,
+      "Bombsite": 1,
+      "CanBePlanter": false
+    },
+    {
+      "Vector": "376.47 -870.68 141.37",
+      "QAngle": "0.00 145.28 0.00",
+      "Team": 3,
+      "Bombsite": 1,
+      "CanBePlanter": false
+    },
+    {
+      "Vector": "797.17 4.97 131.40",
+      "QAngle": "0.00 -30.60 0.00",
       "Team": 2,
       "Bombsite": 1,
       "CanBePlanter": true
     },
     {
-      "Vector": "1112.24 57.82 134.03",
-      "QAngle": "0 136.66 0",
+      "Vector": "1,112.24 57.82 134.03",
+      "QAngle": "0.00 136.66 0.00",
       "Team": 2,
       "Bombsite": 1,
       "CanBePlanter": true
     },
     {
       "Vector": "792.17 152.03 130.03",
-      "QAngle": "0 93.37 0",
+      "QAngle": "0.00 93.37 0.00",
       "Team": 2,
       "Bombsite": 1,
       "CanBePlanter": true
     },
     {
       "Vector": "320.03 292.97 161.65",
-      "QAngle": "0 -78.06 0",
+      "QAngle": "0.00 -78.06 0.00",
       "Team": 2,
       "Bombsite": 1,
       "CanBePlanter": false
     },
     {
-      "Vector": "665.49 -286 138.04",
-      "QAngle": "0 2.8 0",
+      "Vector": "665.49 -286.00 138.04",
+      "QAngle": "0.00 2.80 0.00",
       "Team": 2,
       "Bombsite": 1,
       "CanBePlanter": false
     },
     {
       "Vector": "724.94 -106.86 134.03",
-      "QAngle": "0 79.79 0",
+      "QAngle": "0.00 79.79 0.00",
       "Team": 2,
       "Bombsite": 1,
       "CanBePlanter": false
     },
     {
-      "Vector": "1267.56 323.62 123.47",
-      "QAngle": "0 100.03 0",
+      "Vector": "1,267.56 323.62 123.47",
+      "QAngle": "0.00 100.03 0.00",
       "Team": 2,
       "Bombsite": 1,
       "CanBePlanter": false
     },
     {
-      "Vector": "1036.46 259.77 131.03",
-      "QAngle": "0 49.41 0",
+      "Vector": "1,036.46 259.77 131.03",
+      "QAngle": "0.00 49.41 0.00",
       "Team": 2,
-      "Bombsite": 1,
-      "CanBePlanter": false
-    },
-    {
-      "Vector": "-1668.0312 464.03125 172.82657",
-      "QAngle": "0 -162.97325 0",
-      "Team": 2,
-      "Bombsite": 0,
-      "CanBePlanter": false
-    },
-    {
-      "Vector": "1255.9688 -1479.8372 29.972507",
-      "QAngle": "0 106.60205 0",
-      "Team": 3,
-      "Bombsite": 1,
-      "CanBePlanter": false
-    },
-    {
-      "Vector": "675.819 -1527.5457 -36.934692",
-      "QAngle": "0 44.40091 0",
-      "Team": 3,
-      "Bombsite": 1,
-      "CanBePlanter": false
-    },
-    {
-      "Vector": "-270.01398 -346.72885 164.03125",
-      "QAngle": "0 -88.79391 0",
-      "Team": 3,
-      "Bombsite": 1,
-      "CanBePlanter": false
-    },
-    {
-      "Vector": "-572.1138 -517.33844 36.920486",
-      "QAngle": "0 -39.390106 0",
-      "Team": 3,
-      "Bombsite": 1,
-      "CanBePlanter": false
-    },
-    {
-      "Vector": "-725.75385 -879.97125 35.543415",
-      "QAngle": "0 13.602783 0",
-      "Team": 3,
       "Bombsite": 1,
       "CanBePlanter": false
     }

--- a/RetakesPlugin/map_config/de_ancient_night.json
+++ b/RetakesPlugin/map_config/de_ancient_night.json
@@ -1,0 +1,242 @@
+{
+  "Spawns": [
+    {
+      "Vector": "-1701.56 -1136.77 -21.34",
+      "QAngle": "0 92.42 0",
+      "Team": 3,
+      "Bombsite": 0,
+      "CanBePlanter": false
+    },
+    {
+      "Vector": "-1870.92 -1094.4 -25.68",
+      "QAngle": "0 85.14 0",
+      "Team": 3,
+      "Bombsite": 0,
+      "CanBePlanter": false
+    },
+    {
+      "Vector": "-1461.51 -1156.01 -11.22",
+      "QAngle": "0 120.34 0",
+      "Team": 3,
+      "Bombsite": 0,
+      "CanBePlanter": false
+    },
+    {
+      "Vector": "-530.9 -562.85 34.25",
+      "QAngle": "0 126.89 0",
+      "Team": 3,
+      "Bombsite": 0,
+      "CanBePlanter": false
+    },
+    {
+      "Vector": "-376.98 -589.89 33.63",
+      "QAngle": "0 140.55 0",
+      "Team": 3,
+      "Bombsite": 0,
+      "CanBePlanter": false
+    },
+    {
+      "Vector": "-492.12 78.27 128.83",
+      "QAngle": "0 -126.17 0",
+      "Team": 3,
+      "Bombsite": 0,
+      "CanBePlanter": false
+    },
+    {
+      "Vector": "-555.44 669 138.08",
+      "QAngle": "0 47.42 0",
+      "Team": 3,
+      "Bombsite": 0,
+      "CanBePlanter": false
+    },
+    {
+      "Vector": "143.56 880.04 87.49",
+      "QAngle": "0 -150.13 0",
+      "Team": 3,
+      "Bombsite": 0,
+      "CanBePlanter": false
+    },
+    {
+      "Vector": "14 906.11 74.03",
+      "QAngle": "0 -111.82 0",
+      "Team": 3,
+      "Bombsite": 0,
+      "CanBePlanter": false
+    },
+    {
+      "Vector": "-210.35 723.11 77.66",
+      "QAngle": "0 106.09 0",
+      "Team": 3,
+      "Bombsite": 0,
+      "CanBePlanter": false
+    },
+    {
+      "Vector": "-1226.28 729.97 56.03",
+      "QAngle": "0 178.12 0",
+      "Team": 2,
+      "Bombsite": 0,
+      "CanBePlanter": true
+    },
+    {
+      "Vector": "-1301.03 828.16 54.03",
+      "QAngle": "0 3.14 0",
+      "Team": 2,
+      "Bombsite": 0,
+      "CanBePlanter": true
+    },
+    {
+      "Vector": "-1562.02 731.65 56.03",
+      "QAngle": "0 26.82 0",
+      "Team": 2,
+      "Bombsite": 0,
+      "CanBePlanter": true
+    },
+    {
+      "Vector": "-1527.92 931.31 54.03",
+      "QAngle": "0 -98.86 0",
+      "Team": 2,
+      "Bombsite": 0,
+      "CanBePlanter": false
+    },
+    {
+      "Vector": "-1665.46 1187.97 52.03",
+      "QAngle": "0 -122.5 0",
+      "Team": 2,
+      "Bombsite": 0,
+      "CanBePlanter": false
+    },
+    {
+      "Vector": "-1466.5 1148.96 97.45",
+      "QAngle": "0 45.27 0",
+      "Team": 2,
+      "Bombsite": 0,
+      "CanBePlanter": false
+    },
+    {
+      "Vector": "-178.52 1309.92 28.57",
+      "QAngle": "0 -89.77 0",
+      "Team": 3,
+      "Bombsite": 1,
+      "CanBePlanter": false
+    },
+    {
+      "Vector": "-315.99 1304.19 26.23",
+      "QAngle": "0 -72 0",
+      "Team": 3,
+      "Bombsite": 1,
+      "CanBePlanter": false
+    },
+    {
+      "Vector": "-439.99 1217.56 50.63",
+      "QAngle": "0 -51.58 0",
+      "Team": 3,
+      "Bombsite": 1,
+      "CanBePlanter": false
+    },
+    {
+      "Vector": "-544.63 892.36 103.54",
+      "QAngle": "0 -12.95 0",
+      "Team": 3,
+      "Bombsite": 1,
+      "CanBePlanter": false
+    },
+    {
+      "Vector": "797.17 4.97 131.4",
+      "QAngle": "0 -30.6 0",
+      "Team": 2,
+      "Bombsite": 1,
+      "CanBePlanter": true
+    },
+    {
+      "Vector": "1112.24 57.82 134.03",
+      "QAngle": "0 136.66 0",
+      "Team": 2,
+      "Bombsite": 1,
+      "CanBePlanter": true
+    },
+    {
+      "Vector": "792.17 152.03 130.03",
+      "QAngle": "0 93.37 0",
+      "Team": 2,
+      "Bombsite": 1,
+      "CanBePlanter": true
+    },
+    {
+      "Vector": "320.03 292.97 161.65",
+      "QAngle": "0 -78.06 0",
+      "Team": 2,
+      "Bombsite": 1,
+      "CanBePlanter": false
+    },
+    {
+      "Vector": "665.49 -286 138.04",
+      "QAngle": "0 2.8 0",
+      "Team": 2,
+      "Bombsite": 1,
+      "CanBePlanter": false
+    },
+    {
+      "Vector": "724.94 -106.86 134.03",
+      "QAngle": "0 79.79 0",
+      "Team": 2,
+      "Bombsite": 1,
+      "CanBePlanter": false
+    },
+    {
+      "Vector": "1267.56 323.62 123.47",
+      "QAngle": "0 100.03 0",
+      "Team": 2,
+      "Bombsite": 1,
+      "CanBePlanter": false
+    },
+    {
+      "Vector": "1036.46 259.77 131.03",
+      "QAngle": "0 49.41 0",
+      "Team": 2,
+      "Bombsite": 1,
+      "CanBePlanter": false
+    },
+    {
+      "Vector": "-1668.0312 464.03125 172.82657",
+      "QAngle": "0 -162.97325 0",
+      "Team": 2,
+      "Bombsite": 0,
+      "CanBePlanter": false
+    },
+    {
+      "Vector": "1255.9688 -1479.8372 29.972507",
+      "QAngle": "0 106.60205 0",
+      "Team": 3,
+      "Bombsite": 1,
+      "CanBePlanter": false
+    },
+    {
+      "Vector": "675.819 -1527.5457 -36.934692",
+      "QAngle": "0 44.40091 0",
+      "Team": 3,
+      "Bombsite": 1,
+      "CanBePlanter": false
+    },
+    {
+      "Vector": "-270.01398 -346.72885 164.03125",
+      "QAngle": "0 -88.79391 0",
+      "Team": 3,
+      "Bombsite": 1,
+      "CanBePlanter": false
+    },
+    {
+      "Vector": "-572.1138 -517.33844 36.920486",
+      "QAngle": "0 -39.390106 0",
+      "Team": 3,
+      "Bombsite": 1,
+      "CanBePlanter": false
+    },
+    {
+      "Vector": "-725.75385 -879.97125 35.543415",
+      "QAngle": "0 13.602783 0",
+      "Team": 3,
+      "Bombsite": 1,
+      "CanBePlanter": false
+    }
+  ]
+}


### PR DESCRIPTION
* **chore(deps):** Updated `CounterStrikeSharp.API` from `1.0.330` → `1.0.335`.
* **feat(maps):** Added configuration for the new map `de_ancient_night`.
* **chore(version):** Bumped project version to `2.1.4` and set the minimum version to `CounterStrikeSharp v1.0.335`.

The minimum version required for the plugin to load is now **CounterStrikeSharp v1.0.335**, as loading it on earlier versions is pointless: the server will inevitably crash due to significant changes in the API. This prevents false compatibility.