### PR TITLE
Remove auto join spectator team

### DIFF
--- a/RetakesPlugin/Configs/QueueSettings.cs
+++ b/RetakesPlugin/Configs/QueueSettings.cs
@@ -19,6 +19,9 @@ public class QueueSettings
     [JsonPropertyName("ShouldRemoveSpectators")]
     public bool ShouldRemoveSpectators { get; set; } = true;
 
+    [JsonPropertyName("ShouldAutoJoinSpectators")]
+    public bool ShouldAutoJoinSpectators { get; set; } = true;
+
     public List<QueuePriorityFlagConfig> GetPriorityFlags()
     {
         if (QueuePriorityFlag == null || QueuePriorityFlag.Count == 0)

--- a/RetakesPlugin/Events/PlayerEventHandlers.cs
+++ b/RetakesPlugin/Events/PlayerEventHandlers.cs
@@ -31,6 +31,20 @@ public class PlayerEventHandlers
 
         player.ForceTeamTime = 3600.0f;
 
+        if(_plugin.Config.Queue.ShouldAutoJoinSpectators)
+        {
+            _plugin.AddTimer(1.0f, () =>
+            {
+                if (!PlayerHelper.IsValid(player))
+                {
+                    return;
+                }
+
+                player.ChangeTeam(CsTeam.Spectator);
+                player.ExecuteClientCommand("teammenu");
+            });
+        }
+
         // Grant VIP to contributors
         if (new List<ulong> { 76561198028510846, 76561198044886803, 76561198414501446, 76561199074660131 }.Contains(player.SteamID))
         {

--- a/RetakesPlugin/Events/PlayerEventHandlers.cs
+++ b/RetakesPlugin/Events/PlayerEventHandlers.cs
@@ -31,18 +31,6 @@ public class PlayerEventHandlers
 
         player.ForceTeamTime = 3600.0f;
 
-        // Add small delay to ensure player is fully connected
-        _plugin.AddTimer(1.0f, () =>
-        {
-            if (!PlayerHelper.IsValid(player))
-            {
-                return;
-            }
-
-            player.ChangeTeam(CsTeam.Spectator);
-            player.ExecuteClientCommand("teammenu");
-        });
-
         // Grant VIP to contributors
         if (new List<ulong> { 76561198028510846, 76561198044886803, 76561198414501446, 76561199074660131 }.Contains(player.SteamID))
         {


### PR DESCRIPTION
When you connect to the game, it immediately switches you to spectator mode, and you sit under the map until you call up the team selection window yourself.

