### PR TITLE
Address open issues: crash hardening, retakes_enabled, minimum players, plant location, unload reset, auto-join (+ PR #280)

### DIFF
--- a/.github/workflows/formatting.yml
+++ b/.github/workflows/formatting.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: .NET Format (RetakesPlugin)
         uses: zyactions/dotnet-format@v1

--- a/.github/workflows/plugin-build.yml
+++ b/.github/workflows/plugin-build.yml
@@ -26,60 +26,35 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 8.0.x
+          dotnet-version: 10.0.x
       
       - name: Build RetakesPluginShared
-        run: |
-          cd RetakesPluginShared
-          dotnet build
+        run: dotnet build RetakesPluginShared/RetakesPluginShared.csproj -c Release
       
       - name: Build RetakesPlugin
-        run: |
-          cd RetakesPlugin
-          dotnet build
+        run: dotnet build RetakesPlugin/RetakesPlugin.csproj -c Release
       
-      - name: Create output directory with complete structure
+      - name: Copy additional files
         run: |
-          mkdir -p output/addons/counterstrikesharp/plugins/RetakesPlugin
-          mkdir -p output/addons/counterstrikesharp/shared/RetakesPluginShared
-          
-          # Copy RetakesPlugin files
-          cp ./RetakesPlugin/bin/Debug/net8.0/RetakesPlugin.dll output/addons/counterstrikesharp/plugins/RetakesPlugin/
-          cp ./RetakesPlugin/bin/Debug/net8.0/RetakesPlugin.pdb output/addons/counterstrikesharp/plugins/RetakesPlugin/
-          cp -r ./RetakesPlugin/map_config output/addons/counterstrikesharp/plugins/RetakesPlugin/
-          cp -r ./RetakesPlugin/lang output/addons/counterstrikesharp/plugins/RetakesPlugin/
-          
-          # Copy RetakesPluginShared files
-          cp ./RetakesPluginShared/bin/Debug/net8.0/RetakesPluginShared.dll output/addons/counterstrikesharp/shared/RetakesPluginShared/
-          cp ./RetakesPluginShared/bin/Debug/net8.0/RetakesPluginShared.pdb output/addons/counterstrikesharp/shared/RetakesPluginShared/
-          cp ./RetakesPluginShared/bin/Debug/net8.0/RetakesPluginShared.deps.json output/addons/counterstrikesharp/shared/RetakesPluginShared/
+          cp -r ./RetakesPlugin/map_config ./build-output/addons/counterstrikesharp/plugins/RetakesPlugin/
+          cp -r ./RetakesPlugin/lang ./build-output/addons/counterstrikesharp/plugins/RetakesPlugin/
       
-      - name: Create output directory without map configs
+      - name: Create variant without map configs
         run: |
-          mkdir -p output-no-map-configs/addons/counterstrikesharp/plugins/RetakesPlugin
-          mkdir -p output-no-map-configs/addons/counterstrikesharp/shared/RetakesPluginShared
-          
-          # Copy RetakesPlugin files (without map_config)
-          cp ./RetakesPlugin/bin/Debug/net8.0/RetakesPlugin.dll output-no-map-configs/addons/counterstrikesharp/plugins/RetakesPlugin/
-          cp ./RetakesPlugin/bin/Debug/net8.0/RetakesPlugin.pdb output-no-map-configs/addons/counterstrikesharp/plugins/RetakesPlugin/
-          cp -r ./RetakesPlugin/lang output-no-map-configs/addons/counterstrikesharp/plugins/RetakesPlugin/
-          
-          # Copy RetakesPluginShared files
-          cp ./RetakesPluginShared/bin/Debug/net8.0/RetakesPluginShared.dll output-no-map-configs/addons/counterstrikesharp/shared/RetakesPluginShared/
-          cp ./RetakesPluginShared/bin/Debug/net8.0/RetakesPluginShared.pdb output-no-map-configs/addons/counterstrikesharp/shared/RetakesPluginShared/
-          cp ./RetakesPluginShared/bin/Debug/net8.0/RetakesPluginShared.deps.json output-no-map-configs/addons/counterstrikesharp/shared/RetakesPluginShared/
+          cp -r ./build-output ./build-output-no-map-configs
+          rm -rf ./build-output-no-map-configs/addons/counterstrikesharp/plugins/RetakesPlugin/map_config
       
       - name: Publish artifact (with map configs)
         uses: actions/upload-artifact@v4
         with:
           name: RetakesPlugin-${{ github.sha }}
-          path: output
+          path: ./build-output
       
       - name: Publish artifact (no map configs)
         uses: actions/upload-artifact@v4
         with:
           name: RetakesPlugin-${{ github.sha }}-no-map-configs
-          path: output-no-map-configs
+          path: ./build-output-no-map-configs
   
   release:
     needs: build

--- a/.github/workflows/plugin-build.yml
+++ b/.github/workflows/plugin-build.yml
@@ -21,10 +21,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v6
         with:
           dotnet-version: 10.0.x
       
@@ -45,13 +45,13 @@ jobs:
           rm -rf ./build-output-no-map-configs/addons/counterstrikesharp/plugins/RetakesPlugin/map_config
       
       - name: Publish artifact (with map configs)
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: RetakesPlugin-${{ github.sha }}
           path: ./build-output
       
       - name: Publish artifact (no map configs)
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: RetakesPlugin-${{ github.sha }}-no-map-configs
           path: ./build-output-no-map-configs
@@ -64,13 +64,13 @@ jobs:
 
     steps:
       - name: Download build artifact (with map configs)
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: RetakesPlugin-${{ github.sha }}
           path: ./with-map-configs
 
       - name: Download build artifact (no map configs)
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: RetakesPlugin-${{ github.sha }}-no-map-configs
           path: ./no-map-configs
@@ -83,7 +83,7 @@ jobs:
           zip -r ../RetakesPlugin-${{ github.event.release.tag_name }}-no-map-configs.zip ./addons
 
       - name: Upload release assets
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           files: |
             ./RetakesPlugin-${{ github.event.release.tag_name }}.zip

--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,6 @@
 /.idea
 /RetakesPlugin/.idea
 /RetakesPluginShared/.idea
+/build-output
 *.DotSettings.user
 *.sln

--- a/README.md
+++ b/README.md
@@ -56,19 +56,22 @@ If you'd like to add your own allocator here, make a PR to add it :+1:
 When the plugin is first loaded it will create a `retakes_config.json` file in the plugin directory. This file contains all of the configuration options for the plugin:
 
 ### GameSettings
-| Config                    | Description                                                                                                                             | Default | Min   | Max   |
-|---------------------------|-----------------------------------------------------------------------------------------------------------------------------------------|---------|-------|-------|
-| MaxPlayers                | The maximum number of players allowed in the game at any time. (If you want to increase the max capability you need to add more spawns) | 9       | 2     | 10    |
-| ShouldBreakBreakables     | Whether to break all breakable props on round start (People are noticing rare crashes when this is enabled).                            | false   | false | true  |
-| ShouldOpenDoors           | Whether to open doors on round start (People are noticing rare crashes when this is enabled).                                           | false   | false | true  |
-| EnableFallbackAllocation  | Whether to enable the fallback weapon allocation. You should set this value to false if you're using a standalone weapon allocator.     | true    | false | true  |
+| Config                   | Description                                                                                                                                                                       | Default | Min   | Max  |
+|--------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------|-------|------|
+| MaxPlayers               | The maximum number of players allowed in the game at any time. (If you want to increase the max capability you need to add more spawns)                                           | 9       | 2     | 10   |
+| MinimumPlayers           | The minimum number of human players needed before a retake will start. Below this the server waits in warmup. 0 (default) disables this behaviour; set it to e.g. 2 to enable it. Values above MaxPlayers are clamped. | 0       | 0     | MaxPlayers |
+| ShouldBreakBreakables    | Whether to break all breakable props on round start (People are noticing rare crashes when this is enabled).                                                                      | false   | false | true |
+| ShouldOpenDoors          | Whether to open doors on round start (People are noticing rare crashes when this is enabled).                                                                                     | false   | false | true |
+| EnableFallbackAllocation | Whether to enable the fallback weapon allocation. You should set this value to false if you're using a standalone weapon allocator.                                               | true    | false | true |
 
 ### QueueSettings
-| Config                 | Description                                                                                                   | Default  | Min | Max |
-|------------------------|---------------------------------------------------------------------------------------------------------------|----------|-----|-----|
-| QueuePriorityFlag      | A list of priority flag configurations. Each entry contains DisplayName, Flag, and Priority. Players with higher priority can replace players with lower priority in the queue. | `[{"DisplayName": "VIP", "Flag": "@css/vip", "Priority": 0}]` | 0 | 100 |
-| QueueImmunityFlag      | A list of immunity flag configurations. Each entry contains DisplayName, Flag, and Priority. Players with immunity priority cannot be replaced by players with equal or lower priority. | `[{"DisplayName": "VIP", "Flag": "@css/vip", "Priority": 0}]` | 0 | 100 |
-| ShouldRemoveSpectators | When a player is moved to spectators, remove them from all retake queues. Ensures that AFK plugins work as expected. | true     | false | true |
+| Config                   | Description                                                                                                                                                                                 | Default                                                       | Min   | Max  |
+|--------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------|-------|------|
+| QueuePriorityFlag        | A list of priority flag configurations. Each entry contains DisplayName, Flag, and Priority. Players with higher priority can replace players with lower priority in the queue.             | `[{"DisplayName": "VIP", "Flag": "@css/vip", "Priority": 0}]` | 0     | 100  |
+| QueueImmunityFlag        | A list of immunity flag configurations. Each entry contains DisplayName, Flag, and Priority. Players with immunity priority cannot be replaced by players with equal or lower priority.     | `[{"DisplayName": "VIP", "Flag": "@css/vip", "Priority": 0}]` | 0     | 100  |
+| ShouldRemoveSpectators   | When a player is moved to spectators, remove them from all retake queues. Ensures that AFK plugins work as expected.                                                                        | true                                                          | false | true |
+| ShouldAutoJoinSpectators | Whether to move newly connected players to spectators and open the team menu for them.                                                                                                      | true                                                          | false | true |
+| ShouldAutoJoinGame       | Whether to automatically put newly connected players into the game without showing the team menu: straight in during warmup, otherwise into the queue to be pulled in at the next round. Takes priority over ShouldAutoJoinSpectators. | false                                                         | false | true |
 
 **QueuePriorityFlag and QueueImmunityFlag Configuration:**
 Each flag configuration object has the following properties:
@@ -122,16 +125,27 @@ To disable slot priority and immunity features, set both arrays to empty:
 | EnableBombsiteAnnouncementVoices   | Whether to play the bombsite announcement voices.                                               | false   | false | true |
 | EnableBombsiteAnnouncementCenter   | Whether to display the bombsite in the center announcement box.                                 | true    | false | true |
 | EnableFallbackBombsiteAnnouncement | Whether to enable the fallback bombsite announcement.                                           | true    | false | true |
+| EnablePlantLocationAnnouncement    | Whether to tell the Terrorists where the bomb was planted (e.g. "planted for Short"). Uses the optional `PlantLocation` name on the planter spawn in the map config, falling back to the bombsite letter. | false   | false | true |
 
 ### BombSettings
-| Config             | Description                                                         | Default | Min   | Max  |
-|--------------------|---------------------------------------------------------------------|---------|-------|------|
+| Config             | Description                                                            | Default | Min   | Max  |
+|--------------------|------------------------------------------------------------------------|---------|-------|------|
 | IsAutoPlantEnabled | Whether to enable auto bomb planting at the start of the round or not. | true    | false | true |
 
 ### DebugSettings
-| Config      | Description                                                 | Default | Min   | Max  |
-|-------------|-------------------------------------------------------------|---------|-------|------|
+| Config      | Description                                                  | Default | Min   | Max  |
+|-------------|--------------------------------------------------------------|---------|-------|------|
 | IsDebugMode | Whether to enable debug output to the server console or not. | false   | false | true |
+
+### ConVars
+| ConVar          | Description                                                                                                                                                                                                                                     | Default |
+|-----------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------|
+| retakes_enabled | Enable / disable the retakes gameplay on the fly without unloading the plugin. When set to 0 the plugin stops managing teams, spawns and rounds so you can e.g. practice grenades. Setting it back to 1 restores retakes and restarts the game. | 1       |
+
+### Server config files
+When the plugin first loads it creates two config files in `cfg/cs2-retakes/`:
+- `retakes.cfg` is executed on every map start and contains the convars required for retakes to work, plus some you may want to tweak.
+- `retakes_unload.cfg` is executed when the plugin is unloaded, and restores the convars that `retakes.cfg` changes back to sensible defaults. Adjust it to suit your server.
 
 ## Commands
 
@@ -151,10 +165,10 @@ To disable slot priority and immunity features, set both arrays to empty:
 | !showspawns        | <A / B>                           | Show the spawns for the specified bombsite.                          | @css/root   |
 | !spawns            | <A / B>                           | Show the spawns for the specified bombsite (alias).                  | @css/root   |
 | !edit              | <A / B>                           | Show the spawns for the specified bombsite (alias).                  | @css/root   |
-| !addspawn          | <CT / T> <Y / N (can be planter)> | Adds a retakes spawn point for the bombsite spawns currently shown.  | @css/root   |
-| !add               | <CT / T> <Y / N (can be planter)> | Adds a retakes spawn point (alias).                                  | @css/root   |
-| !newspawn          | <CT / T> <Y / N (can be planter)> | Adds a retakes spawn point (alias).                                  | @css/root   |
-| !new               | <CT / T> <Y / N (can be planter)> | Adds a retakes spawn point (alias).                                  | @css/root   |
+| !addspawn          | <CT / T> <Y / N (can be planter)> [plant location name] | Adds a retakes spawn point for the bombsite spawns currently shown. The optional plant location name (e.g. "Short") is stored on planter spawns and used by EnablePlantLocationAnnouncement. | @css/root   |
+| !add               | <CT / T> <Y / N (can be planter)> [plant location name] | Adds a retakes spawn point (alias).                                  | @css/root   |
+| !newspawn          | <CT / T> <Y / N (can be planter)> [plant location name] | Adds a retakes spawn point (alias).                                  | @css/root   |
+| !new               | <CT / T> <Y / N (can be planter)> [plant location name] | Adds a retakes spawn point (alias).                                  | @css/root   |
 | !removespawn       |                                   | Removes the nearest spawn point for the bombsite currently shown.    | @css/root   |
 | !remove            |                                   | Removes the nearest spawn point (alias).                             | @css/root   |
 | !deletespawn       |                                   | Removes the nearest spawn point (alias).                             | @css/root   |
@@ -166,14 +180,14 @@ To disable slot priority and immunity features, set both arrays to empty:
 | !exitedit          |                                   | Exits the spawn editing mode (alias).                                | @css/root   |
 
 ### Map Config Commands
-| Command            | Arguments          | Description                                    | Permissions |
-|--------------------|--------------------|------------------------------------------------|-------------|
-| !mapconfig         | <Config file name> | Forces a specific map config file to load.     | @css/root   |
-| !setmapconfig      | <Config file name> | Forces a specific map config file to load (alias). | @css/root   |
-| !loadmapconfig     | <Config file name> | Forces a specific map config file to load (alias). | @css/root   |
-| !mapconfigs        |                    | Displays a list of available map configs.     | @css/root   |
-| !viewmapconfigs    |                    | Displays a list of available map configs (alias). | @css/root   |
-| !listmapconfigs    |                    | Displays a list of available map configs (alias). | @css/root   |
+| Command         | Arguments          | Description                                        | Permissions |
+|-----------------|--------------------|----------------------------------------------------|-------------|
+| !mapconfig      | <Config file name> | Forces a specific map config file to load.         | @css/root   |
+| !setmapconfig   | <Config file name> | Forces a specific map config file to load (alias). | @css/root   |
+| !loadmapconfig  | <Config file name> | Forces a specific map config file to load (alias). | @css/root   |
+| !mapconfigs     |                    | Displays a list of available map configs.          | @css/root   |
+| !viewmapconfigs |                    | Displays a list of available map configs (alias).  | @css/root   |
+| !listmapconfigs |                    | Displays a list of available map configs (alias).  | @css/root   |
 
 ## Stay up to date
 Subscribe to **release** notifications and stay up to date with the latest features and patches:

--- a/RetakesPlugin/Commands/SpawnEditor/AddSpawnCommand.cs
+++ b/RetakesPlugin/Commands/SpawnEditor/AddSpawnCommand.cs
@@ -51,7 +51,7 @@ public class AddSpawnCommand
 
         if (commandInfo.ArgCount < 2)
         {
-            commandInfo.ReplyToCommand($"{_plugin.Localizer["retakes.prefix"]} Usage: !add [T/CT] [Y/N can be planter]");
+            commandInfo.ReplyToCommand($"{_plugin.Localizer["retakes.prefix"]} Usage: !add [T/CT] [Y/N can be planter] [plant location name]");
             return;
         }
 
@@ -96,6 +96,22 @@ public class AddSpawnCommand
             return;
         }
 
+        string? plantLocation = null;
+        if (commandInfo.ArgCount > 3)
+        {
+            var plantLocationParts = new List<string>();
+            for (var argIndex = 3; argIndex < commandInfo.ArgCount; argIndex++)
+            {
+                plantLocationParts.Add(commandInfo.GetArg(argIndex));
+            }
+
+            plantLocation = string.Join(" ", plantLocationParts).Trim();
+            if (string.IsNullOrWhiteSpace(plantLocation))
+            {
+                plantLocation = null;
+            }
+        }
+
         var newSpawn = new Spawn(
             vector: player!.PlayerPawn.Value!.AbsOrigin!,
             qAngle: player!.PlayerPawn.Value!.AbsRotation!
@@ -105,6 +121,15 @@ public class AddSpawnCommand
             CanBePlanter = team == "T" && !string.IsNullOrWhiteSpace(canBePlanterInput) ? canBePlanterInput == "Y" : player.PlayerPawn.Value.InBombZoneTrigger,
             Bombsite = (Bombsite)_showSpawnsCommand.ShowingSpawnsForBombsite
         };
+
+        if (newSpawn.CanBePlanter)
+        {
+            newSpawn.PlantLocation = plantLocation;
+        }
+        else if (plantLocation != null)
+        {
+            commandInfo.ReplyToCommand($"{_plugin.Localizer["retakes.prefix"]} Plant location name ignored because this spawn can't be a planter spawn.");
+        }
 
         SpawnService.ShowSpawn(newSpawn);
 

--- a/RetakesPlugin/Configs/GameSettings.cs
+++ b/RetakesPlugin/Configs/GameSettings.cs
@@ -7,6 +7,9 @@ public class GameSettings
     [JsonPropertyName("MaxPlayers")]
     public int MaxPlayers { get; set; } = 9;
 
+    [JsonPropertyName("MinimumPlayers")]
+    public int MinimumPlayers { get; set; } = 0;
+
     [JsonPropertyName("ShouldBreakBreakables")]
     public bool ShouldBreakBreakables { get; set; } = false;
 

--- a/RetakesPlugin/Configs/MapConfigSettings.cs
+++ b/RetakesPlugin/Configs/MapConfigSettings.cs
@@ -12,4 +12,7 @@ public class MapConfigSettings
 
     [JsonPropertyName("EnableFallbackBombsiteAnnouncement")]
     public bool EnableFallbackBombsiteAnnouncement { get; set; } = true;
+
+    [JsonPropertyName("EnablePlantLocationAnnouncement")]
+    public bool EnablePlantLocationAnnouncement { get; set; } = false;
 }

--- a/RetakesPlugin/Configs/QueueSettings.cs
+++ b/RetakesPlugin/Configs/QueueSettings.cs
@@ -22,6 +22,9 @@ public class QueueSettings
     [JsonPropertyName("ShouldAutoJoinSpectators")]
     public bool ShouldAutoJoinSpectators { get; set; } = true;
 
+    [JsonPropertyName("ShouldAutoJoinGame")]
+    public bool ShouldAutoJoinGame { get; set; } = false;
+
     public List<QueuePriorityFlagConfig> GetPriorityFlags()
     {
         if (QueuePriorityFlag == null || QueuePriorityFlag.Count == 0)

--- a/RetakesPlugin/Events/PlayerEventHandlers.cs
+++ b/RetakesPlugin/Events/PlayerEventHandlers.cs
@@ -31,16 +31,30 @@ public class PlayerEventHandlers
 
         player.ForceTeamTime = 3600.0f;
 
-        if(_plugin.Config.Queue.ShouldAutoJoinSpectators)
+        if (_plugin.Config.Queue.ShouldAutoJoinGame)
         {
             _plugin.AddTimer(1.0f, () =>
             {
-                if (!PlayerHelper.IsValid(player))
+                if (!PlayerHelper.IsValid(player) || !PlayerHelper.IsConnected(player))
                 {
                     return;
                 }
 
-                player.ChangeTeam(CsTeam.Spectator);
+                _gameManager.QueueManager.AddConnectingPlayer(player);
+                _gameManager.CheckMinimumPlayers();
+                _gameManager.RestartGameIfEmpty();
+            });
+        }
+        else if (_plugin.Config.Queue.ShouldAutoJoinSpectators)
+        {
+            _plugin.AddTimer(1.0f, () =>
+            {
+                if (!PlayerHelper.IsValid(player) || !PlayerHelper.IsConnected(player))
+                {
+                    return;
+                }
+
+                PlayerHelper.TryChangeTeam(player, CsTeam.Spectator);
                 player.ExecuteClientCommand("teammenu");
             });
         }
@@ -78,7 +92,7 @@ public class PlayerEventHandlers
 
             if (!player.IsBot)
             {
-                player.ChangeTeam(CsTeam.Spectator);
+                PlayerHelper.TryChangeTeam(player, CsTeam.Spectator);
             }
             else if (!player.IsHLTV)
             {

--- a/RetakesPlugin/Events/RoundEventHandlers.cs
+++ b/RetakesPlugin/Events/RoundEventHandlers.cs
@@ -78,6 +78,16 @@ public class RoundEventHandlers
         _gameManager.QueueManager.Update();
         _gameManager.QueueManager.DebugQueues(false);
 
+        if (_gameManager.ShouldWaitForPlayers())
+        {
+            Logger.LogInfo("Round", "Not enough players to start a retake, waiting for players");
+            _gameManager.StartWaitingForPlayers();
+            return HookResult.Continue;
+        }
+
+        // Heal any stale waiting state, e.g. if an admin manually ran mp_warmup_end
+        _gameManager.CancelWaitingForPlayers();
+
         _gameManager.OnRoundPreStart(_lastRoundWinner);
         _gameManager.QueueManager.SetRoundTeams();
 
@@ -120,6 +130,12 @@ public class RoundEventHandlers
             return HookResult.Continue;
         }
 
+        if (_gameManager.IsWaitingForPlayers)
+        {
+            Logger.LogDebug("Round", "Waiting for players, skipping round start logic");
+            return HookResult.Continue;
+        }
+
         if (_spawnManager == null)
         {
             Logger.LogDebug("Round", "Spawn manager not loaded.");
@@ -155,6 +171,12 @@ public class RoundEventHandlers
         if (gameRules.WarmupPeriod)
         {
             Logger.LogDebug("Round", "Warmup round, skipping post-start logic");
+            return HookResult.Continue;
+        }
+
+        if (_gameManager.IsWaitingForPlayers)
+        {
+            Logger.LogDebug("Round", "Waiting for players, skipping post-start logic");
             return HookResult.Continue;
         }
 
@@ -207,6 +229,12 @@ public class RoundEventHandlers
             return HookResult.Continue;
         }
 
+        if (_gameManager.IsWaitingForPlayers)
+        {
+            Logger.LogDebug("Round", "Waiting for players, skipping freeze end logic");
+            return HookResult.Continue;
+        }
+
         if (PlayerHelper.GetPlayerCount(CsTeam.Terrorist) > 0)
         {
             HandleAutoPlant();
@@ -225,6 +253,8 @@ public class RoundEventHandlers
     public HookResult OnBombPlanted(EventBombPlanted @event, GameEventInfo info)
     {
         Logger.LogInfo("Round", "Bomb planted");
+
+        _announcementService.AnnouncePlantLocation(_spawnManager.CurrentPlanterSpawn?.PlantLocation, _currentBombsite);
 
         _plugin.AddTimer(4.1f, () =>
         {

--- a/RetakesPlugin/Managers/GameManager.cs
+++ b/RetakesPlugin/Managers/GameManager.cs
@@ -103,9 +103,9 @@ public class GameManager
     {
         var humanCount = QueueManager.GetHumanActivePlayerCount();
 
-        // Rate limit so jointeam spam can't flood the chat
+        // Rate limit purely on time so join/leave flapping can't flood the chat either
         var timeSinceLastAnnounce = Server.CurrentTime - _lastWaitingAnnounceTime;
-        if (humanCount == _lastAnnouncedWaitingCount && timeSinceLastAnnounce >= 0 && timeSinceLastAnnounce < WaitingAnnounceCooldownSeconds)
+        if (timeSinceLastAnnounce >= 0 && timeSinceLastAnnounce < WaitingAnnounceCooldownSeconds)
         {
             return;
         }

--- a/RetakesPlugin/Managers/GameManager.cs
+++ b/RetakesPlugin/Managers/GameManager.cs
@@ -16,12 +16,15 @@ public class GameManager
     private readonly bool _isScrambleEnabled;
     private readonly bool _removeSpectatorsEnabled;
     private readonly bool _isBalanceEnabled;
+    private readonly int _minimumPlayers;
+    private float _lastRestartGameTime = -RestartGameCooldownSeconds;
 
     public const int ScoreForKill = 50;
     public const int ScoreForAssist = 25;
     public const int ScoreForDefuse = 50;
+    private const float RestartGameCooldownSeconds = 3.0f;
 
-    public GameManager(RetakesPlugin plugin, QueueManager queueManager, int? roundsToScramble, bool? isScrambleEnabled, bool? removeSpectatorsEnabled, bool? isBalanceEnabled)
+    public GameManager(RetakesPlugin plugin, QueueManager queueManager, int? roundsToScramble, bool? isScrambleEnabled, bool? removeSpectatorsEnabled, bool? isBalanceEnabled, int? minimumPlayers)
     {
         _plugin = plugin;
         QueueManager = queueManager;
@@ -29,8 +32,116 @@ public class GameManager
         _isScrambleEnabled = isScrambleEnabled ?? true;
         _removeSpectatorsEnabled = removeSpectatorsEnabled ?? false;
         _isBalanceEnabled = isBalanceEnabled ?? true;
+        // Clamp so a misconfigured value can never leave the server waiting forever
+        _minimumPlayers = Math.Min(minimumPlayers ?? 0, queueManager.MaxRetakesPlayers);
 
         Logger.LogInfo("GameManager", "Game manager initialized");
+    }
+
+    public bool IsWaitingForPlayers { get; private set; }
+
+    public bool ShouldWaitForPlayers()
+    {
+        return QueueManager.GetHumanActivePlayerCount() < _minimumPlayers;
+    }
+
+    public void StartWaitingForPlayers()
+    {
+        var alreadyWaiting = IsWaitingForPlayers;
+
+        // Always re-assert the paused warmup so the hold recovers from an
+        // unexpected round restart happening while we were already waiting.
+        IsWaitingForPlayers = true;
+        Server.ExecuteCommand("mp_warmup_start");
+        Server.ExecuteCommand("mp_warmup_pausetimer 1");
+
+        if (!alreadyWaiting)
+        {
+            AnnounceWaitingForPlayers();
+            Logger.LogInfo("GameManager", $"Waiting for players ({QueueManager.GetHumanActivePlayerCount()}/{_minimumPlayers})");
+        }
+    }
+
+    public void CancelWaitingForPlayers()
+    {
+        if (!IsWaitingForPlayers)
+        {
+            return;
+        }
+
+        IsWaitingForPlayers = false;
+        Server.ExecuteCommand("mp_warmup_pausetimer 0");
+        Logger.LogInfo("GameManager", "Waiting for players cancelled");
+    }
+
+    public void CheckMinimumPlayers()
+    {
+        if (!IsWaitingForPlayers)
+        {
+            return;
+        }
+
+        if (ShouldWaitForPlayers())
+        {
+            AnnounceWaitingForPlayers();
+            return;
+        }
+
+        IsWaitingForPlayers = false;
+        Server.ExecuteCommand("mp_warmup_pausetimer 0");
+        Server.ExecuteCommand("mp_warmup_end");
+
+        Server.PrintToChatAll($"{_plugin.Localizer["retakes.prefix"]} {_plugin.Localizer["retakes.queue.minimum_players_reached"]}");
+        Logger.LogInfo("GameManager", "Minimum players reached, starting the game");
+    }
+
+    private float _lastWaitingAnnounceTime = -WaitingAnnounceCooldownSeconds;
+    private int _lastAnnouncedWaitingCount = -1;
+    private const float WaitingAnnounceCooldownSeconds = 10.0f;
+
+    private void AnnounceWaitingForPlayers()
+    {
+        var humanCount = QueueManager.GetHumanActivePlayerCount();
+
+        // Rate limit so jointeam spam can't flood the chat
+        var timeSinceLastAnnounce = Server.CurrentTime - _lastWaitingAnnounceTime;
+        if (humanCount == _lastAnnouncedWaitingCount && timeSinceLastAnnounce >= 0 && timeSinceLastAnnounce < WaitingAnnounceCooldownSeconds)
+        {
+            return;
+        }
+
+        _lastAnnouncedWaitingCount = humanCount;
+        _lastWaitingAnnounceTime = Server.CurrentTime;
+
+        Server.PrintToChatAll($"{_plugin.Localizer["retakes.prefix"]} {_plugin.Localizer["retakes.queue.waiting_for_players", humanCount, _minimumPlayers]}");
+    }
+
+    public void RestartGameIfEmpty()
+    {
+        if (IsWaitingForPlayers)
+        {
+            // The server is already parked in a paused warmup, restarting would tear it down
+            return;
+        }
+
+        if (QueueManager.ActivePlayers.Count != 0)
+        {
+            return;
+        }
+
+        var timeSinceLastRestart = Server.CurrentTime - _lastRestartGameTime;
+        if (timeSinceLastRestart >= 0 && timeSinceLastRestart < RestartGameCooldownSeconds)
+        {
+            Logger.LogDebug("GameManager", "Skipping game restart, cooldown active");
+            return;
+        }
+
+        _lastRestartGameTime = Server.CurrentTime;
+
+        Logger.LogDebug("GameManager", "No active players, updating queue and restarting game");
+        QueueManager.ClearRoundTeams();
+        QueueManager.Update();
+        GameRulesHelper.RestartGame();
     }
 
     private bool _scrambleNextRound;
@@ -316,11 +427,11 @@ public class GameManager
         {
             if (terrorists.Contains(player))
             {
-                player.SwitchTeam(CsTeam.Terrorist);
+                PlayerHelper.TrySwitchTeam(player, CsTeam.Terrorist);
             }
             else if (counterTerrorists.Contains(player))
             {
-                player.SwitchTeam(CsTeam.CounterTerrorist);
+                PlayerHelper.TrySwitchTeam(player, CsTeam.CounterTerrorist);
             }
         }
 

--- a/RetakesPlugin/Managers/QueueManager.cs
+++ b/RetakesPlugin/Managers/QueueManager.cs
@@ -39,7 +39,14 @@ public class QueueManager
 
     public int GetHumanActivePlayerCount()
     {
-        return ActivePlayers.Count(player => PlayerHelper.IsValid(player) && !player.IsBot && !player.IsHLTV);
+        // Queued humans count too, otherwise bots occupying active slots could
+        // stop a MinimumPlayers hold from ever releasing
+        return ActivePlayers.Count(IsHumanPlayer) + QueuePlayers.Count(IsHumanPlayer);
+    }
+
+    private static bool IsHumanPlayer(CCSPlayerController player)
+    {
+        return PlayerHelper.IsValid(player) && !player.IsBot && !player.IsHLTV;
     }
 
     public int GetTargetNumTerrorists()
@@ -111,8 +118,9 @@ public class QueueManager
 
         if (!QueuePlayers.Contains(player))
         {
-            // Players explicitly choosing to spectate should not be tracked as wanting to play
-            if (toTeam != CsTeam.Terrorist && toTeam != CsTeam.CounterTerrorist)
+            // Players explicitly choosing to spectate should not be tracked as wanting
+            // to play. CsTeam.None (the auto-select button) still falls through below.
+            if (toTeam == CsTeam.Spectator)
             {
                 return HookResult.Continue;
             }

--- a/RetakesPlugin/Managers/QueueManager.cs
+++ b/RetakesPlugin/Managers/QueueManager.cs
@@ -1,3 +1,4 @@
+using CounterStrikeSharp.API;
 using CounterStrikeSharp.API.Core;
 using CounterStrikeSharp.API.Modules.Utils;
 
@@ -32,6 +33,13 @@ public class QueueManager
         _shouldPreventTeamChangesMidRound = shouldPreventTeamChangesMidRound ?? true;
 
         Logger.LogInfo("QueueManager", $"Queue manager initialized (Max: {_maxRetakesPlayers}, T Ratio: {_terroristRatio})");
+    }
+
+    public int MaxRetakesPlayers => _maxRetakesPlayers;
+
+    public int GetHumanActivePlayerCount()
+    {
+        return ActivePlayers.Count(player => PlayerHelper.IsValid(player) && !player.IsBot && !player.IsHLTV);
     }
 
     public int GetTargetNumTerrorists()
@@ -93,7 +101,7 @@ public class QueueManager
                     player.CommitSuicide(false, true);
                 }
 
-                player.ChangeTeam(CsTeam.Spectator);
+                PlayerHelper.TryChangeTeam(player, CsTeam.Spectator);
                 return HookResult.Handled;
             }
 
@@ -103,6 +111,12 @@ public class QueueManager
 
         if (!QueuePlayers.Contains(player))
         {
+            // Players explicitly choosing to spectate should not be tracked as wanting to play
+            if (toTeam != CsTeam.Terrorist && toTeam != CsTeam.CounterTerrorist)
+            {
+                return HookResult.Continue;
+            }
+
             var gameRules = GameRulesHelper.GetGameRulesOrNull();
             if ((gameRules?.WarmupPeriod ?? false) && ActivePlayers.Count < _maxRetakesPlayers)
             {
@@ -203,14 +217,19 @@ public class QueueManager
 
             var queuePlayerDisplayName = PlayerHelper.GetQueuePriorityDisplayName(queuePlayer, _queuePriorityFlags);
 
-            replaceablePlayer.ChangeTeam(CsTeam.Spectator);
+            if (!PlayerHelper.TryChangeTeam(queuePlayer, CsTeam.CounterTerrorist))
+            {
+                Logger.LogWarning("QueueManager", $"Could not move {queuePlayer.PlayerName} to CT, skipping queue priority swap");
+                continue;
+            }
+
+            PlayerHelper.TryChangeTeam(replaceablePlayer, CsTeam.Spectator);
             ActivePlayers.Remove(replaceablePlayer);
             QueuePlayers.Add(replaceablePlayer);
             replaceablePlayer.PrintToChat($"{_plugin.Localizer["retakes.prefix"]} {_plugin.Localizer["retakes.queue.replaced_by_vip", queuePlayer.PlayerName, queuePlayerDisplayName]}");
 
             ActivePlayers.Add(queuePlayer);
             QueuePlayers.Remove(queuePlayer);
-            queuePlayer.ChangeTeam(CsTeam.CounterTerrorist);
             queuePlayer.PrintToChat($"{_plugin.Localizer["retakes.prefix"]} {_plugin.Localizer["retakes.queue.vip_took_place", replaceablePlayer.PlayerName, queuePlayerDisplayName]}");
 
             Logger.LogInfo("QueueManager", $"{queuePlayer.PlayerName} ({queuePlayerDisplayName}, priority: {queuePlayerPriority}) replaced {replaceablePlayer.PlayerName} (priority: {replaceablePlayerData.Priority})");
@@ -243,13 +262,13 @@ public class QueueManager
 
             foreach (var player in playersToAddList)
             {
-                if (!PlayerHelper.IsValid(player))
+                if (!PlayerHelper.TryChangeTeam(player, CsTeam.CounterTerrorist))
                 {
+                    Logger.LogWarning("QueueManager", $"Could not move {player.PlayerName} from queue to active, skipping");
                     continue;
                 }
 
                 ActivePlayers.Add(player);
-                player.ChangeTeam(CsTeam.CounterTerrorist);
                 Logger.LogInfo("QueueManager", $"Moved {player.PlayerName} from queue to active");
             }
         }
@@ -269,6 +288,74 @@ public class QueueManager
                 player.PrintToChat($"{_plugin.Localizer["retakes.prefix"]} {waitingMessage}");
             }
         }
+    }
+
+    public void AddConnectingPlayer(CCSPlayerController player)
+    {
+        if (!PlayerHelper.IsValid(player) || player.IsBot || player.IsHLTV)
+        {
+            return;
+        }
+
+        if (ActivePlayers.Contains(player) || QueuePlayers.Contains(player))
+        {
+            return;
+        }
+
+        PlayerJoinedTeam(player, CsTeam.None, CsTeam.CounterTerrorist);
+
+        if (ActivePlayers.Contains(player))
+        {
+            PlayerHelper.TryChangeTeam(player, CsTeam.CounterTerrorist);
+            Logger.LogInfo("QueueManager", $"Auto joined {player.PlayerName} into the game");
+        }
+        else
+        {
+            PlayerHelper.TryChangeTeam(player, CsTeam.Spectator);
+            Logger.LogInfo("QueueManager", $"Auto joined {player.PlayerName} into the queue");
+        }
+    }
+
+    public void SyncActivePlayersFromTeams()
+    {
+        foreach (var player in Utilities.GetPlayers())
+        {
+            if (!PlayerHelper.IsValid(player) || !PlayerHelper.IsConnected(player) || player.IsBot || player.IsHLTV)
+            {
+                continue;
+            }
+
+            if (player.Team != CsTeam.Terrorist && player.Team != CsTeam.CounterTerrorist)
+            {
+                continue;
+            }
+
+            if (ActivePlayers.Contains(player) || QueuePlayers.Contains(player))
+            {
+                continue;
+            }
+
+            if (ActivePlayers.Count < _maxRetakesPlayers)
+            {
+                ActivePlayers.Add(player);
+            }
+            else
+            {
+                QueuePlayers.Add(player);
+                PlayerHelper.TryChangeTeam(player, CsTeam.Spectator);
+                player.PrintToChat($"{_plugin.Localizer["retakes.prefix"]} {_plugin.Localizer["retakes.queue.joined"]}");
+            }
+        }
+
+        Logger.LogInfo("QueueManager", $"Synced players from teams: {ActivePlayers.Count} active, {QueuePlayers.Count} queued");
+    }
+
+    public void ClearAllQueues()
+    {
+        ActivePlayers.Clear();
+        QueuePlayers.Clear();
+        ClearRoundTeams();
+        Logger.LogInfo("QueueManager", "All queues cleared");
     }
 
     public void RemovePlayerFromQueues(CCSPlayerController player)

--- a/RetakesPlugin/Managers/SpawnManager.cs
+++ b/RetakesPlugin/Managers/SpawnManager.cs
@@ -14,6 +14,8 @@ public class SpawnManager
     private readonly Dictionary<Bombsite, Dictionary<CsTeam, List<Spawn>>> _spawns = new();
     private readonly Random _random = new();
 
+    public Spawn? CurrentPlanterSpawn { get; private set; }
+
     public SpawnManager(MapConfigService mapConfigService)
     {
         _mapConfigService = mapConfigService;
@@ -89,6 +91,7 @@ public class SpawnManager
         }
 
         var randomPlanterSpawn = planterSpawns[_random.Next(planterSpawns.Count)];
+        CurrentPlanterSpawn = randomPlanterSpawn;
         spawns[CsTeam.Terrorist].Remove(randomPlanterSpawn);
 
         CCSPlayerController? planter = null;

--- a/RetakesPlugin/Models/Spawn.cs
+++ b/RetakesPlugin/Models/Spawn.cs
@@ -23,4 +23,8 @@ public class Spawn
     public CsTeam Team { get; set; }
     public Bombsite Bombsite { get; set; }
     public bool CanBePlanter { get; set; }
+
+    // Optional callout name for planter spawns, e.g. "Short" or "Default"
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? PlantLocation { get; set; }
 }

--- a/RetakesPlugin/RetakesPlugin.cs
+++ b/RetakesPlugin/RetakesPlugin.cs
@@ -3,6 +3,7 @@ using CounterStrikeSharp.API.Core;
 using CounterStrikeSharp.API.Core.Attributes;
 using CounterStrikeSharp.API.Core.Capabilities;
 using CounterStrikeSharp.API.Modules.Commands;
+using CounterStrikeSharp.API.Modules.Cvars;
 using RetakesPluginShared;
 using System.Text.Json;
 
@@ -24,7 +25,7 @@ namespace RetakesPlugin;
 [MinimumApiVersion(345)]
 public class RetakesPlugin : BasePlugin, IPluginConfig<BaseConfigs>
 {
-    public const string Version = "3.0.4";
+    public const string Version = "3.1.0";
 
     #region Plugin Info
     public override string ModuleName => "Retakes Plugin";
@@ -90,6 +91,13 @@ public class RetakesPlugin : BasePlugin, IPluginConfig<BaseConfigs>
     private readonly HashSet<CCSPlayerController> _hasMutedVoices = [];
     #endregion
 
+    #region ConVars
+    public FakeConVar<bool> RetakesEnabledConVar = new("retakes_enabled", "Whether the retakes plugin is enabled or not.", true);
+    private bool _lastEnabledState = true;
+    #endregion
+
+    public bool IsPluginEnabled => RetakesEnabledConVar.Value;
+
     public RetakesPlugin()
     {
         _jsonOptions = new JsonSerializerOptions
@@ -109,6 +117,8 @@ public class RetakesPlugin : BasePlugin, IPluginConfig<BaseConfigs>
 
         RegisterListener<Listeners.OnMapStart>(OnMapStart);
         AddCommandListener("jointeam", OnCommandJoinTeam);
+
+        RetakesEnabledConVar.ValueChanged += OnRetakesEnabledChanged;
 
         var retakesPluginEventSender = new RetakesPluginEventSender();
         Capabilities.RegisterPluginCapability(RetakesPluginEventSenderCapability, () => retakesPluginEventSender);
@@ -143,15 +153,55 @@ public class RetakesPlugin : BasePlugin, IPluginConfig<BaseConfigs>
 
         SpawnService.Reset();
 
-        AddTimer(1.0f, ServerHelper.ExecuteRetakesConfiguration);
+        AddTimer(1.0f, () =>
+        {
+            if (IsPluginEnabled)
+            {
+                ServerHelper.ExecuteRetakesConfiguration();
+            }
+        });
 
         InitializeServices(mapName);
+    }
+
+    private void OnRetakesEnabledChanged(object? sender, bool isEnabled)
+    {
+        if (isEnabled == _lastEnabledState)
+        {
+            return;
+        }
+
+        _lastEnabledState = isEnabled;
+
+        if (isEnabled)
+        {
+            Utils.Logger.LogInfo("Main", "Retakes enabled via retakes_enabled convar");
+            Server.PrintToChatAll($"{Localizer["retakes.prefix"]} {Localizer["retakes.plugin.enabled"]}");
+
+            ServerHelper.ExecuteRetakesConfiguration();
+            _gameManager?.QueueManager.SyncActivePlayersFromTeams();
+            GameRulesHelper.RestartGame();
+        }
+        else
+        {
+            Utils.Logger.LogInfo("Main", "Retakes disabled via retakes_enabled convar");
+            Server.PrintToChatAll($"{Localizer["retakes.prefix"]} {Localizer["retakes.plugin.disabled"]}");
+
+            // Make sure we don't leave the server stuck in a paused warmup
+            _gameManager?.CancelWaitingForPlayers();
+            Server.ExecuteCommand("mp_warmup_pausetimer 0");
+            ServerHelper.ExecuteRetakesUnloadConfiguration();
+            _gameManager?.QueueManager.ClearAllQueues();
+        }
     }
 
     private void InitializeServices(string mapName, string? customMapConfig = null)
     {
         try
         {
+            // A previous game manager may be holding the server in a paused warmup
+            _gameManager?.CancelWaitingForPlayers();
+
             // Initialize MapConfigService
             _mapConfigService = new MapConfigService(ModuleDirectory, customMapConfig ?? mapName, _jsonOptions);
             _mapConfigService.Load();
@@ -174,7 +224,8 @@ public class RetakesPlugin : BasePlugin, IPluginConfig<BaseConfigs>
                 Config.Team.RoundsToScramble,
                 Config.Team.IsScrambleEnabled,
                 Config.Queue.ShouldRemoveSpectators,
-                Config.Team.IsBalanceEnabled
+                Config.Team.IsBalanceEnabled,
+                Config.Game.MinimumPlayers
             );
 
             _breakerManager = new BreakerManager(
@@ -187,7 +238,8 @@ public class RetakesPlugin : BasePlugin, IPluginConfig<BaseConfigs>
                 _random,
                 _hasMutedVoices,
                 Config.MapConfig.EnableBombsiteAnnouncementVoices,
-                Config.MapConfig.EnableBombsiteAnnouncementCenter
+                Config.MapConfig.EnableBombsiteAnnouncementCenter,
+                Config.MapConfig.EnablePlantLocationAnnouncement
             );
 
             // Initialize Event Handlers
@@ -291,61 +343,117 @@ public class RetakesPlugin : BasePlugin, IPluginConfig<BaseConfigs>
     #region Event Handlers
     private HookResult OnPlayerConnectFull(EventPlayerConnectFull @event, GameEventInfo info)
     {
+        if (!IsPluginEnabled)
+        {
+            return HookResult.Continue;
+        }
+
         return _playerEventHandlers?.OnPlayerConnectFull(@event, info) ?? HookResult.Continue;
     }
 
     private HookResult OnRoundPreStart(EventRoundPrestart @event, GameEventInfo info)
     {
+        if (!IsPluginEnabled)
+        {
+            return HookResult.Continue;
+        }
+
         return _roundEventHandlers?.OnRoundPreStart(@event, info) ?? HookResult.Continue;
     }
 
     private HookResult OnRoundStart(EventRoundStart @event, GameEventInfo info)
     {
+        if (!IsPluginEnabled)
+        {
+            return HookResult.Continue;
+        }
+
         return _roundEventHandlers?.OnRoundStart(@event, info) ?? HookResult.Continue;
     }
 
     private HookResult OnRoundPostStart(EventRoundPoststart @event, GameEventInfo info)
     {
+        if (!IsPluginEnabled)
+        {
+            return HookResult.Continue;
+        }
+
         return _roundEventHandlers?.OnRoundPostStart(@event, info) ?? HookResult.Continue;
     }
 
     private HookResult OnRoundFreezeEnd(EventRoundFreezeEnd @event, GameEventInfo info)
     {
+        if (!IsPluginEnabled)
+        {
+            return HookResult.Continue;
+        }
+
         return _roundEventHandlers?.OnRoundFreezeEnd(@event, info) ?? HookResult.Continue;
     }
 
     private HookResult OnRoundEnd(EventRoundEnd @event, GameEventInfo info)
     {
+        if (!IsPluginEnabled)
+        {
+            return HookResult.Continue;
+        }
+
         return _roundEventHandlers?.OnRoundEnd(@event, info) ?? HookResult.Continue;
     }
 
     private HookResult OnPlayerSpawn(EventPlayerSpawn @event, GameEventInfo info)
     {
+        if (!IsPluginEnabled)
+        {
+            return HookResult.Continue;
+        }
+
         return _playerEventHandlers?.OnPlayerSpawn(@event, info) ?? HookResult.Continue;
     }
 
     private HookResult OnPlayerDeath(EventPlayerDeath @event, GameEventInfo info)
     {
+        if (!IsPluginEnabled)
+        {
+            return HookResult.Continue;
+        }
+
         return _playerEventHandlers?.OnPlayerDeath(@event, info) ?? HookResult.Continue;
     }
 
     private HookResult OnBombPlanted(EventBombPlanted @event, GameEventInfo info)
     {
+        if (!IsPluginEnabled)
+        {
+            return HookResult.Continue;
+        }
+
         return _roundEventHandlers?.OnBombPlanted(@event, info) ?? HookResult.Continue;
     }
 
     private HookResult OnBombDefused(EventBombDefused @event, GameEventInfo info)
     {
+        if (!IsPluginEnabled)
+        {
+            return HookResult.Continue;
+        }
+
         return _roundEventHandlers?.OnBombDefused(@event, info) ?? HookResult.Continue;
     }
 
     private HookResult OnPlayerDisconnect(EventPlayerDisconnect @event, GameEventInfo info)
     {
+        // Always run so we never leave stale players in the queues
         return _playerEventHandlers?.OnPlayerDisconnect(@event, info) ?? HookResult.Continue;
     }
 
     private HookResult OnPlayerTeam(EventPlayerTeam @event, GameEventInfo info)
     {
+        if (!IsPluginEnabled)
+        {
+            return HookResult.Continue;
+        }
+
         return _playerEventHandlers?.OnPlayerTeam(@event, info) ?? HookResult.Continue;
     }
     #endregion
@@ -353,6 +461,11 @@ public class RetakesPlugin : BasePlugin, IPluginConfig<BaseConfigs>
     #region Command Handlers
     private HookResult OnCommandJoinTeam(CCSPlayerController? player, CommandInfo commandInfo)
     {
+        if (!IsPluginEnabled)
+        {
+            return HookResult.Continue;
+        }
+
         if (_gameManager == null)
         {
             Utils.Logger.LogWarning("Commands", "Game manager not loaded");
@@ -372,13 +485,8 @@ public class RetakesPlugin : BasePlugin, IPluginConfig<BaseConfigs>
         var response = _gameManager.QueueManager.PlayerJoinedTeam(player, fromTeam, toTeam);
         _gameManager.QueueManager.DebugQueues(false);
 
-        if (_gameManager.QueueManager.ActivePlayers.Count == 0)
-        {
-            Utils.Logger.LogDebug("Commands", "No active players, updating queue and restarting game");
-            _gameManager.QueueManager.ClearRoundTeams();
-            _gameManager.QueueManager.Update();
-            GameRulesHelper.RestartGame();
-        }
+        _gameManager.CheckMinimumPlayers();
+        _gameManager.RestartGameIfEmpty();
 
         return response;
     }
@@ -387,6 +495,12 @@ public class RetakesPlugin : BasePlugin, IPluginConfig<BaseConfigs>
     public override void Unload(bool hotReload)
     {
         Utils.Logger.LogInfo("Main", "Plugin unloading...");
+
+        if (!hotReload)
+        {
+            ServerHelper.ExecuteRetakesUnloadConfiguration();
+        }
+
         base.Unload(hotReload);
     }
 }

--- a/RetakesPlugin/RetakesPlugin.cs
+++ b/RetakesPlugin/RetakesPlugin.cs
@@ -22,7 +22,7 @@ using RetakesPlugin.Commands.SpawnEditor;
 
 namespace RetakesPlugin;
 
-[MinimumApiVersion(345)]
+[MinimumApiVersion(369)]
 public class RetakesPlugin : BasePlugin, IPluginConfig<BaseConfigs>
 {
     public const string Version = "3.1.0";

--- a/RetakesPlugin/RetakesPlugin.csproj
+++ b/RetakesPlugin/RetakesPlugin.csproj
@@ -1,14 +1,21 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <OutputPath>..\build-output\addons\counterstrikesharp\plugins\RetakesPlugin\</OutputPath>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+    <DebugType>portable</DebugType>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CounterStrikeSharp.API" Version="1.0.368" />
+    <PackageReference Include="CounterStrikeSharp.API" Version="1.0.369" />
     <PackageReference Include="Microsoft.Extensions.Localization.Abstractions" Version="10.0.10" />
-    <ProjectReference Include="..\RetakesPluginShared\RetakesPluginShared.csproj" />
+    <ProjectReference Include="..\RetakesPluginShared\RetakesPluginShared.csproj"><Private>false</Private></ProjectReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="lang\**\*.*" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
   <Target Name="PostBuild" AfterTargets="PostBuildEvent" Condition=" '$(CopyPath)' != '' ">

--- a/RetakesPlugin/Services/AnnouncementService.cs
+++ b/RetakesPlugin/Services/AnnouncementService.cs
@@ -13,6 +13,7 @@ public class AnnouncementService
     private readonly HashSet<CCSPlayerController> _hasMutedVoices;
     private readonly bool _voicesEnabled;
     private readonly bool _centerEnabled;
+    private readonly bool _plantLocationEnabled;
 
     private static readonly string[] BombsiteAnnouncers =
     [
@@ -25,13 +26,37 @@ public class AnnouncementService
         "swat_fem"
     ];
 
-    public AnnouncementService(RetakesPlugin plugin, Random random, HashSet<CCSPlayerController> hasMutedVoices, bool voicesEnabled, bool centerEnabled)
+    public AnnouncementService(RetakesPlugin plugin, Random random, HashSet<CCSPlayerController> hasMutedVoices, bool voicesEnabled, bool centerEnabled, bool plantLocationEnabled)
     {
         _plugin = plugin;
         _random = random;
         _hasMutedVoices = hasMutedVoices;
         _voicesEnabled = voicesEnabled;
         _centerEnabled = centerEnabled;
+        _plantLocationEnabled = plantLocationEnabled;
+    }
+
+    public void AnnouncePlantLocation(string? plantLocation, Bombsite bombsite)
+    {
+        if (!_plantLocationEnabled)
+        {
+            return;
+        }
+
+        // Fall back to the bombsite letter when the planter spawn has no callout name configured
+        var locationName = string.IsNullOrWhiteSpace(plantLocation) ? bombsite.ToString() : plantLocation;
+
+        var message = $"{_plugin.Localizer["retakes.prefix"]} {_plugin.Localizer["retakes.bombsite.plant_location", locationName]}";
+
+        foreach (var player in Utilities.GetPlayers())
+        {
+            if (player.Team == CounterStrikeSharp.API.Modules.Utils.CsTeam.Terrorist)
+            {
+                player.PrintToChat(message);
+            }
+        }
+
+        Logger.LogInfo("Announcement", $"Announced plant location: {locationName}");
     }
 
     public void AnnounceBombsite(Bombsite bombsite, bool onlyCenter = false)

--- a/RetakesPlugin/Utils/GameRulesHelper.cs
+++ b/RetakesPlugin/Utils/GameRulesHelper.cs
@@ -34,7 +34,14 @@ public static class GameRulesHelper
 
     public static void RestartGame()
     {
-        if (!GetGameRules().WarmupPeriod)
+        var gameRules = GetGameRulesOrNull();
+        if (gameRules == null)
+        {
+            Logger.LogWarning("GameRules", "Game rules not available, skipping game restart");
+            return;
+        }
+
+        if (!gameRules.WarmupPeriod)
         {
             CheckRoundDone();
         }

--- a/RetakesPlugin/Utils/PlayerHelper.cs
+++ b/RetakesPlugin/Utils/PlayerHelper.cs
@@ -21,6 +21,44 @@ public static class PlayerHelper
         return player.Connected == PlayerConnectedState.Connected;
     }
 
+    public static bool TryChangeTeam(CCSPlayerController? player, CsTeam team)
+    {
+        if (!IsValid(player) || !IsConnected(player))
+        {
+            return false;
+        }
+
+        try
+        {
+            player.ChangeTeam(team);
+            return true;
+        }
+        catch (Exception ex)
+        {
+            Logger.LogWarning("PlayerHelper", $"Failed to change team for {player.PlayerName}: {ex.Message}");
+            return false;
+        }
+    }
+
+    public static bool TrySwitchTeam(CCSPlayerController? player, CsTeam team)
+    {
+        if (!IsValid(player) || !IsConnected(player))
+        {
+            return false;
+        }
+
+        try
+        {
+            player.SwitchTeam(team);
+            return true;
+        }
+        catch (Exception ex)
+        {
+            Logger.LogWarning("PlayerHelper", $"Failed to switch team for {player.PlayerName}: {ex.Message}");
+            return false;
+        }
+    }
+
     public static bool HasAlivePawn(CCSPlayerController? player, bool shouldBeAlive = true)
     {
         if (!IsValid(player))

--- a/RetakesPlugin/Utils/ServerHelper.cs
+++ b/RetakesPlugin/Utils/ServerHelper.cs
@@ -21,6 +21,13 @@ public static class ServerHelper
             MigrateRetakesConfig();
         }
 
+        // Create the unload config eagerly so server owners can customise it
+        // before the plugin is ever unloaded
+        if (!File.Exists(RetakesUnloadCfgPath))
+        {
+            CreateRetakesUnloadConfig();
+        }
+
         Server.ExecuteCommand("exec cs2-retakes/retakes.cfg");
         Logger.LogInfo("Server", "Retakes configuration executed");
     }
@@ -36,8 +43,8 @@ public static class ServerHelper
             // default is migrated, custom values are left alone.
             var migrated = Regex.Replace(
                 contents,
-                @"(?m)^(\s*)mp_roundtime_defuse\s+0\.25\s*$",
-                "${1}mp_roundtime_defuse 1.25");
+                @"(?m)^([ \t]*)mp_roundtime_defuse[ \t]+0\.25[ \t]*(\r?)$",
+                "${1}mp_roundtime_defuse 1.25${2}");
 
             if (migrated != contents)
             {

--- a/RetakesPlugin/Utils/ServerHelper.cs
+++ b/RetakesPlugin/Utils/ServerHelper.cs
@@ -1,4 +1,5 @@
 using System.Text;
+using System.Text.RegularExpressions;
 using CounterStrikeSharp.API;
 
 namespace RetakesPlugin.Utils;
@@ -7,6 +8,7 @@ public static class ServerHelper
 {
     private static string RetakesCfgDirectory => Path.Combine(Server.GameDirectory, "csgo", "cfg", "cs2-retakes");
     private static string RetakesCfgPath => Path.Combine(RetakesCfgDirectory, "retakes.cfg");
+    private static string RetakesUnloadCfgPath => Path.Combine(RetakesCfgDirectory, "retakes_unload.cfg");
 
     public static void ExecuteRetakesConfiguration()
     {
@@ -14,9 +16,103 @@ public static class ServerHelper
         {
             CreateRetakesConfig();
         }
+        else
+        {
+            MigrateRetakesConfig();
+        }
 
         Server.ExecuteCommand("exec cs2-retakes/retakes.cfg");
         Logger.LogInfo("Server", "Retakes configuration executed");
+    }
+
+    private static void MigrateRetakesConfig()
+    {
+        try
+        {
+            var contents = File.ReadAllText(RetakesCfgPath);
+
+            // The previously shipped default of mp_roundtime_defuse 0.25 makes the
+            // 10 second bomb warning play at the wrong time. Only the exact old
+            // default is migrated, custom values are left alone.
+            var migrated = Regex.Replace(
+                contents,
+                @"(?m)^(\s*)mp_roundtime_defuse\s+0\.25\s*$",
+                "${1}mp_roundtime_defuse 1.25");
+
+            if (migrated != contents)
+            {
+                File.WriteAllText(RetakesCfgPath, migrated);
+                Logger.LogInfo("Server", "Migrated mp_roundtime_defuse 0.25 -> 1.25 in retakes.cfg (fixes the bomb warning sound timing)");
+            }
+        }
+        catch (Exception ex)
+        {
+            Logger.LogException("Server", ex);
+        }
+    }
+
+    public static void ExecuteRetakesUnloadConfiguration()
+    {
+        if (!File.Exists(RetakesUnloadCfgPath))
+        {
+            CreateRetakesUnloadConfig();
+        }
+
+        Server.ExecuteCommand("exec cs2-retakes/retakes_unload.cfg");
+        Logger.LogInfo("Server", "Retakes unload configuration executed");
+    }
+
+    private static void CreateRetakesUnloadConfig()
+    {
+        try
+        {
+            Directory.CreateDirectory(RetakesCfgDirectory);
+
+            var unloadCfgContents = @"
+                // This file is executed when the retakes plugin is unloaded.
+                // It restores the game convars that retakes.cfg changes back to
+                // sensible defaults. Adjust these values to suit your server.
+                bot_quota 10
+                mp_autoteambalance 1
+                mp_forcecamera 1
+                mp_give_player_c4 1
+                mp_halftime 1
+                mp_join_grace_time 30
+                mp_match_can_clinch 1
+                mp_maxmoney 16000
+                mp_playercashawards 1
+                mp_teamcashawards 1
+                mp_solid_teammates 1
+                mp_warmup_pausetimer 0
+                mp_roundtime_defuse 1.92
+                mp_autokick 1
+                mp_c4timer 40
+                mp_freezetime 15
+                mp_friendlyfire 0
+                mp_round_restart_delay 7
+                mp_match_restart_delay 25
+                mp_maxrounds 24
+                mp_timelimit 0
+                mp_warmuptime 60
+                sv_talk_enemy_dead 0
+                sv_talk_enemy_living 0
+                sv_deadtalk 0
+                spec_replay_enable 1
+                mp_death_drop_gun 1
+                mp_death_drop_defuser 1
+                mp_death_drop_grenade 1
+
+                echo [Retakes] Unload config loaded!
+            ";
+
+            File.WriteAllText(RetakesUnloadCfgPath, unloadCfgContents, Encoding.UTF8);
+
+            Logger.LogInfo("Server", "Created retakes_unload.cfg file");
+        }
+        catch (Exception ex)
+        {
+            Logger.LogException("Server", ex);
+        }
     }
 
     private static void CreateRetakesConfig()

--- a/RetakesPlugin/Utils/ServerHelper.cs
+++ b/RetakesPlugin/Utils/ServerHelper.cs
@@ -144,7 +144,7 @@ public static class ServerHelper
                 sv_skirmish_id 0
 
                 // Things you can change, and may want to:
-                mp_roundtime_defuse 0.25
+                mp_roundtime_defuse 1.25
                 mp_autokick 0
                 mp_c4timer 40
                 mp_freezetime 1

--- a/RetakesPlugin/lang/ar.json
+++ b/RetakesPlugin/lang/ar.json
@@ -3,14 +3,19 @@
   "retakes.no_permissions": "ليس لديك الإذن لاستخدام هذا الأمر.",
   "retakes.enabled": "{red}معطل{default}",
   "retakes.disabled": "{green}مفعل{default}",
+  "retakes.plugin.enabled": "تم {green}تفعيل{default} إضافة retakes.",
+  "retakes.plugin.disabled": "تم {red}تعطيل{default} إضافة retakes.",
 
   "retakes.queue.joined": "لقد تم وضعك في قائمة الانتظار.",
   "retakes.queue.waiting": "اللعبة ممتلئة حالياً ب{green}{0}{default} لاعبين. أنت في قائمة الانتظار.",
+  "retakes.queue.waiting_for_players": "بانتظار اللاعبين: {green}{0}{default}/{green}{1}{default}. ستبدأ اللعبة عند انضمام عدد كافٍ من اللاعبين.",
+  "retakes.queue.minimum_players_reached": "انضم عدد كافٍ من اللاعبين - اللعبة تبدأ الآن!",
   "retakes.queue.replaced_by_vip": "لقد تم استبدالك بلاعب {gold}{1}{default} {green}{0}{default}.",
   "retakes.queue.vip_took_place": "لقد أخذت مكان {green}{0}{default} في اللعبة لأنك {gold}{1}{default}.",
 
   "retakes.bombsite.announcement": "إعادة الاستيلاء على {green}{0}{default}: {lightred}{1} من الإرهابيين{default} مقابل {purple}{2} من قوات مكافحة الإرهاب",
   "retakes.center.bombsite.announcement": "إعادة الاستيلاء على {green}{0}{default}: {lightred}{1} من الإرهابيين{default} مقابل {purple}{2} من قوات مكافحة الإرهاب",
+  "retakes.bombsite.plant_location": "تم زرع القنبلة في {green}{0}{default}.",
   "retakes.voices.toggle": "لديك {0} الإعلانات الصوتية!",
 
   "retakes.teams.scramble": "فاز الإرهابيون {green}{0}{default} جولات متتالية. {purple}يتم خلط الفرق!",

--- a/RetakesPlugin/lang/da.json
+++ b/RetakesPlugin/lang/da.json
@@ -3,14 +3,19 @@
   "retakes.no_permissions": "Du har ikke tilladelse til at bruge denne kommando.",
   "retakes.enabled": "{red}deaktiveret{default}",
   "retakes.disabled": "{green}aktiveret{default}",
+  "retakes.plugin.enabled": "Retakes-pluginnet er blevet {green}aktiveret{default}.",
+  "retakes.plugin.disabled": "Retakes-pluginnet er blevet {red}deaktiveret{default}.",
 
   "retakes.queue.joined": "Du er blevet placeret i køen.",
   "retakes.queue.waiting": "Dette spil er fuldt med {green}{0}{default} spillere. Du er blevet placeret i køen.",
+  "retakes.queue.waiting_for_players": "Venter på spillere: {green}{0}{default}/{green}{1}{default}. Spillet starter, når der er nok spillere.",
+  "retakes.queue.minimum_players_reached": "Der er nu nok spillere - spillet starter!",
   "retakes.queue.replaced_by_vip": "Du er blevet erstattet af {gold}{1}{default}-spilleren {green}{0}{default}.",
   "retakes.queue.vip_took_place": "Du har taget {green}{0}{default}s plads i spillet, fordi du er {gold}{1}{default}.",
 
   "retakes.bombsite.announcement": "Retake {green}{0}{default}: {lightred}{1} T'er{default} mod {purple}{2} CT'er",
   "retakes.center.bombsite.announcement": "Retake {green}{0}{default}: {lightred}{1} T'er{default} mod {purple}{2} CT'er",
+  "retakes.bombsite.plant_location": "Bomben er plantet på {green}{0}{default}.",
   "retakes.voices.toggle": "Du har {0} stemmeannonceringer!",
 
   "retakes.teams.scramble": "Terroristerne har vundet {green}{0}{default} runder i træk. {purple}Holdende bliver blandet!",

--- a/RetakesPlugin/lang/de.json
+++ b/RetakesPlugin/lang/de.json
@@ -3,14 +3,19 @@
   "retakes.no_permissions": "Du hast keine Berechtigung, diesen Befehl zu verwenden.",
   "retakes.enabled": "{red}deaktiviert{default}",
   "retakes.disabled": "{green}aktiviert{default}",
+  "retakes.plugin.enabled": "Das Retakes-Plugin wurde {green}aktiviert{default}.",
+  "retakes.plugin.disabled": "Das Retakes-Plugin wurde {red}deaktiviert{default}.",
 
   "retakes.queue.joined": "Sie befinden sich in der Warteschlange.",
   "retakes.queue.waiting": "Das Spiel ist aktuell voll mit {green}{0}{default} Spielern. Sie sind in der Warteschlange.",
+  "retakes.queue.waiting_for_players": "Warte auf Spieler: {green}{0}{default}/{green}{1}{default}. Das Spiel startet, sobald genügend Spieler beigetreten sind.",
+  "retakes.queue.minimum_players_reached": "Genügend Spieler sind beigetreten - das Spiel startet!",
   "retakes.queue.replaced_by_vip": "Sie wurden durch {gold}{1}{default}-Spieler {green}{0}{default} ersetzt.",
   "retakes.queue.vip_took_place": "Sie haben {green}{0}{default}s Platz im Spiel eingenommen, weil Sie {gold}{1}{default} sind.",
 
   "retakes.bombsite.announcement": "Retake {green}{0}{default}: {lightred}{1} Ts{default} vs {purple}{2} CTs",
   "retakes.center.bombsite.announcement": "Retake {green}{0}{default}: {lightred}{1} Ts{default} vs {purple}{2} CTs",
+  "retakes.bombsite.plant_location": "Die Bombe wurde bei {green}{0}{default} gelegt.",
   "retakes.voices.toggle": "Sie haben {0} Sprachansagen!",
 
   "retakes.teams.scramble": "Die Terroristen haben {green}{0}{default} Runden in Folge gewonnen. {purple}Teams werden gemischt!",

--- a/RetakesPlugin/lang/en.json
+++ b/RetakesPlugin/lang/en.json
@@ -3,14 +3,19 @@
   "retakes.no_permissions": "You don't have permission to use this command.",
   "retakes.enabled": "{red}disabled{default}",
   "retakes.disabled": "{green}enabled{default}",
+  "retakes.plugin.enabled": "The retakes plugin has been {green}enabled{default}.",
+  "retakes.plugin.disabled": "The retakes plugin has been {red}disabled{default}.",
 
   "retakes.queue.joined": "You have been placed in the waiting queue.",
   "retakes.queue.waiting": "The game is currently full with {green}{0}{default} players. You are in the waiting queue.",
+  "retakes.queue.waiting_for_players": "Waiting for players: {green}{0}{default}/{green}{1}{default}. The game will start once enough players have joined.",
+  "retakes.queue.minimum_players_reached": "Enough players have joined - the game is starting!",
   "retakes.queue.replaced_by_vip": "You have been replaced by {gold}{1}{default} player {green}{0}{default}.",
   "retakes.queue.vip_took_place": "You have taken {green}{0}{default}'s place in the game for being {gold}{1}{default}.",
 
   "retakes.bombsite.announcement": "Retake {green}{0}{default}: {lightred}{1} Ts{default} vs {purple}{2} CTs",
   "retakes.center.bombsite.announcement": "Retake {green}{0}{default}: {lightred}{1} Ts{default} vs {purple}{2} CTs",
+  "retakes.bombsite.plant_location": "The bomb has been planted for {green}{0}{default}.",
   "retakes.voices.toggle": "You have {0} voice announcements!",
 
   "retakes.teams.scramble": "The terrorists won {green}{0}{default} rounds in a row. {purple}Teams are being scrambled!",

--- a/RetakesPlugin/lang/es.json
+++ b/RetakesPlugin/lang/es.json
@@ -3,14 +3,19 @@
   "retakes.no_permissions": "No tienes permiso para usar este comando.",
   "retakes.enabled": "{red}deshabilitado{default}",
   "retakes.disabled": "{green}habilitado{default}",
+  "retakes.plugin.enabled": "El plugin de retakes ha sido {green}activado{default}.",
+  "retakes.plugin.disabled": "El plugin de retakes ha sido {red}desactivado{default}.",
 
   "retakes.queue.joined": "Fuiste puesto en la lista de espera.",
   "retakes.queue.waiting": "La partida está llena con {green}{0}{default} jugadores. Te encuentras en la lista de espera.",
+  "retakes.queue.waiting_for_players": "Esperando jugadores: {green}{0}{default}/{green}{1}{default}. La partida comenzará cuando haya suficientes jugadores.",
+  "retakes.queue.minimum_players_reached": "¡Ya hay suficientes jugadores - la partida está comenzando!",
   "retakes.queue.replaced_by_vip": "Has sido reemplazado por el jugador {gold}{1}{default} {green}{0}{default}.",
   "retakes.queue.vip_took_place": "Has tomado el lugar de {green}{0}{default} por ser {gold}{1}{default}.",
 
   "retakes.bombsite.announcement": "Retake {green}{0}{default}: {lightred}{1} Ts{default} vs {purple}{2} CTs",
   "retakes.center.bombsite.announcement": "Retake {green}{0}{default}: {lightred}{1} Ts{default} vs {purple}{2} CTs",
+  "retakes.bombsite.plant_location": "La bomba está plantada en {green}{0}{default}.",
   "retakes.voices.toggle": "¡Tienes {0} anuncios de voz!",
 
   "retakes.teams.scramble": "Los terroristas ganaron {green}{0}{default} rondas seguidas. {purple}Los equipos serán mezclados!",

--- a/RetakesPlugin/lang/fi.json
+++ b/RetakesPlugin/lang/fi.json
@@ -3,14 +3,19 @@
   "retakes.no_permissions": "Sinulla ei ole oikeutta käyttää tätä komentoa.",
   "retakes.enabled": "{red}pois käytöstä{default}",
   "retakes.disabled": "{green}käytössä{default}",
+  "retakes.plugin.enabled": "Retakes-lisäosa on {green}otettu käyttöön{default}.",
+  "retakes.plugin.disabled": "Retakes-lisäosa on {red}poistettu käytöstä{default}.",
 
   "retakes.queue.joined": "Sinut on laitettu jonoon odottamaan peliin siirtymistä.",
   "retakes.queue.waiting": "Peli on tällä hetkellä täysi {green}{0}{default} pelaajalla. Olet jonossa odottamassa peliin.",
+  "retakes.queue.waiting_for_players": "Odotetaan pelaajia: {green}{0}{default}/{green}{1}{default}. Peli alkaa, kun pelaajia on tarpeeksi.",
+  "retakes.queue.minimum_players_reached": "Pelaajia on nyt tarpeeksi - peli alkaa!",
   "retakes.queue.replaced_by_vip": "Sinun paikkasi pelissä otti {gold}{1}{default} pelaaja {green}{0}{default}.",
   "retakes.queue.vip_took_place": "Olet ottanut pelaajan {green}{0}{default} paikan pelissä, koska olet {gold}{1}{default}.",
 
   "retakes.bombsite.announcement": "Retake {green}{0}{default}: {lightred}{1} Ts{default} vs {purple}{2} CTs",
   "retakes.center.bombsite.announcement": "Retake {green}{0}{default}: {lightred}{1} Ts{default} vs {purple}{2} CTs",
+  "retakes.bombsite.plant_location": "Pommi on asetettu paikkaan {green}{0}{default}.",
   "retakes.voices.toggle": "Sinulla on {0} äänitiedotukset!",
 
   "retakes.teams.scramble": "Terot ovat voittaneet {green}{0}{default} kierrosta putkeen. {purple}Tiimit sekoitetaan!",

--- a/RetakesPlugin/lang/fr.json
+++ b/RetakesPlugin/lang/fr.json
@@ -3,14 +3,19 @@
   "retakes.no_permissions": "Vous n'avez pas la permission d'utiliser cette commande.",
   "retakes.enabled": "{red}désactivé{default}",
   "retakes.disabled": "{green}activé{default}",
+  "retakes.plugin.enabled": "Le plugin retakes a été {green}activé{default}.",
+  "retakes.plugin.disabled": "Le plugin retakes a été {red}désactivé{default}.",
 
   "retakes.queue.joined": "Vous avez été placé dans la file d'attente.",
   "retakes.queue.waiting": "La partie est actuellement complète avec {green}{0}{default} joueurs. Vous êtes dans la file d'attente.",
+  "retakes.queue.waiting_for_players": "En attente de joueurs : {green}{0}{default}/{green}{1}{default}. La partie commencera lorsqu'il y aura assez de joueurs.",
+  "retakes.queue.minimum_players_reached": "Assez de joueurs ont rejoint - la partie commence !",
   "retakes.queue.replaced_by_vip": "Vous avez été remplacé par le joueur {gold}{1}{default} {green}{0}{default}.",
   "retakes.queue.vip_took_place": "Vous avez pris la place de {green}{0}{default} dans le jeu pour être {gold}{1}{default}.",
 
   "retakes.bombsite.announcement": "Reprise {green}{0}{default}: {lightred}{1} Terroristes{default} contre {purple}{2} CTs",
   "retakes.center.bombsite.announcement": "Reprise {green}{0}{default}: {lightred}{1} Terroristes{default} contre {purple}{2} CTs",
+  "retakes.bombsite.plant_location": "La bombe est posée à {green}{0}{default}.",
   "retakes.voices.toggle": "Vous avez {0} les annonces vocales!",
 
   "retakes.teams.scramble": "Les terroristes ont gagné {green}{0}{default} tours d'affilée. {purple}Mélange des équipes en cours !",

--- a/RetakesPlugin/lang/hu.json
+++ b/RetakesPlugin/lang/hu.json
@@ -3,14 +3,19 @@
   "retakes.no_permissions": "Nincs jogosultságod használni ezt a parancsot.",
   "retakes.enabled": "{red}letiltva{default}",
   "retakes.disabled": "{green}engedélyezve{default}",
+  "retakes.plugin.enabled": "A retakes plugin {green}engedélyezve{default} lett.",
+  "retakes.plugin.disabled": "A retakes plugin {red}letiltva{default} lett.",
 
   "retakes.queue.joined": "Át lettél rakva a várólistába.",
   "retakes.queue.waiting": "Játék jelenleg fullon van {green}{0}{default} játékossal. Bent vagy a várólistában.",
+  "retakes.queue.waiting_for_players": "Várakozás játékosokra: {green}{0}{default}/{green}{1}{default}. A játék elindul, amint elegen csatlakoztak.",
+  "retakes.queue.minimum_players_reached": "Elegendő játékos csatlakozott - a játék indul!",
   "retakes.queue.replaced_by_vip": "Egy {gold}{1}{default} játékos, {green}{0}{default} helyettesített téged.",
   "retakes.queue.vip_took_place": "Átvetted {green}{0}{default} helyét a játékban, mert {gold}{1}{default} vagy.",
 
   "retakes.bombsite.announcement": "Retake {green}{0}{default}: {lightred}{1} T-k{default} vs {purple}{2} TE-k",
   "retakes.center.bombsite.announcement": "Retake {green}{0}{default}: {lightred}{1} T-k{default} vs {purple}{2} TE-k",
+  "retakes.bombsite.plant_location": "A bomba itt van élesítve: {green}{0}{default}.",
   "retakes.voices.toggle": "{0} hangos bejelentéseid vannak!",
 
   "retakes.teams.scramble": "Terroristák {green}{0}{default} kört nyertek egymás után. {purple}A csapatok össze lettek keverve!",

--- a/RetakesPlugin/lang/no.json
+++ b/RetakesPlugin/lang/no.json
@@ -3,14 +3,19 @@
   "retakes.no_permissions": "Du har ikke tillatelse til å bruke denne kommandoen.",
   "retakes.enabled": "{red}deaktivert{default}",
   "retakes.disabled": "{green}aktivert{default}",
+  "retakes.plugin.enabled": "Retakes-pluginen har blitt {green}aktivert{default}.",
+  "retakes.plugin.disabled": "Retakes-pluginen har blitt {red}deaktivert{default}.",
 
   "retakes.queue.joined": "Du har blitt plassert i kø for å bli med.",
   "retakes.queue.waiting": "Spillet er for øyeblikket fullt med {green}{0}{default} spillere. Du er nå i køen for å bli med.",
+  "retakes.queue.waiting_for_players": "Venter på spillere: {green}{0}{default}/{green}{1}{default}. Spillet starter når det er nok spillere.",
+  "retakes.queue.minimum_players_reached": "Det er nå nok spillere - spillet starter!",
   "retakes.queue.replaced_by_vip": "Du har blitt erstattet av {gold}{1}{default}-spilleren {green}{0}{default}.",
   "retakes.queue.vip_took_place": "Du har tatt {green}{0}{default}s plass i spillet fordi du er {gold}{1}{default}.",
 
   "retakes.bombsite.announcement": "Retake {green}{0}{default}: {lightred}{1} Ts{default} mot {purple}{2} CTs",
   "retakes.center.bombsite.announcement": "Retake {green}{0}{default}: {lightred}{1} Ts{default} mot {purple}{2} CTs",
+  "retakes.bombsite.plant_location": "Bomben er plantet på {green}{0}{default}.",
   "retakes.voices.toggle": "Du har {0} stemme kunngjøringer!",
 
   "retakes.teams.scramble": "Terroristene har vunnet {green}{0}{default} runder på rad. {purple}Lagene blir samlet!",

--- a/RetakesPlugin/lang/pl.json
+++ b/RetakesPlugin/lang/pl.json
@@ -3,14 +3,19 @@
   "retakes.no_permissions": "Nie masz uprawnień do użycia tej komendy.",
   "retakes.enabled": "{red}wyłączone{default}",
   "retakes.disabled": "{green}włączone{default}",
+  "retakes.plugin.enabled": "Plugin retakes został {green}włączony{default}.",
+  "retakes.plugin.disabled": "Plugin retakes został {red}wyłączony{default}.",
 
   "retakes.queue.joined": "Zostałeś dodany do kolejki.",
   "retakes.queue.waiting": "Gra jest pełna z {green}{0}{default} graczami. Jesteś aktualnie w kolejce.",
+  "retakes.queue.waiting_for_players": "Oczekiwanie na graczy: {green}{0}{default}/{green}{1}{default}. Gra rozpocznie się, gdy dołączy wystarczająca liczba graczy.",
+  "retakes.queue.minimum_players_reached": "Dołączyła wystarczająca liczba graczy - gra się rozpoczyna!",
   "retakes.queue.replaced_by_vip": "Zostałeś zastąpiony przez gracza {gold}{1}{default} {green}{0}{default}.",
   "retakes.queue.vip_took_place": "Zająłeś miejsce {green}{0}{default} w grze, ponieważ jesteś {gold}{1}{default}.",
 
   "retakes.bombsite.announcement": "Retake {green}{0}{default}: {lightred}{1} Ts{default} vs {purple}{2} CTs",
   "retakes.center.bombsite.announcement": "Retake {green}{0}{default}: {lightred}{1} Ts{default} vs {purple}{2} CTs",
+  "retakes.bombsite.plant_location": "Bomba jest podłożona na {green}{0}{default}.",
   "retakes.voices.toggle": "Masz {0} głosowe ogłoszenia!",
 
   "retakes.teams.scramble": "Terroryści wygrali {green}{0}{default} rund pod rząd. {purple}Drużyny zostaną wymieszane!",

--- a/RetakesPlugin/lang/pt-BR.json
+++ b/RetakesPlugin/lang/pt-BR.json
@@ -3,14 +3,19 @@
   "retakes.no_permissions": "Não tens permissão para usar este comando.",
   "retakes.enabled": "{red}desativado{default}",
   "retakes.disabled": "{green}ativado{default}",
+  "retakes.plugin.enabled": "O plugin de retakes foi {green}ativado{default}.",
+  "retakes.plugin.disabled": "O plugin de retakes foi {red}desativado{default}.",
   
   "retakes.queue.joined": "Você foi colocado na fila de espera, aguarde a próxima rodada.",
   "retakes.queue.waiting": "Os times estão cheios no momento com {green}{0}{default} jogadores. Você está na fila de espera, aguarde!",
+  "retakes.queue.waiting_for_players": "Aguardando jogadores: {green}{0}{default}/{green}{1}{default}. O jogo começará quando houver jogadores suficientes.",
+  "retakes.queue.minimum_players_reached": "Jogadores suficientes entraram - o jogo está começando!",
   "retakes.queue.replaced_by_vip": "Você foi substituído pelo jogador {gold}{1}{default} {green}{0}{default}.",
   "retakes.queue.vip_took_place": "Você ocupou o lugar de {green}{0}{default} no jogo por ser {gold}{1}{default}.",
 
   "retakes.bombsite.announcement": "Retake {green}{0}{default}: {lightred}{1} Ts{default} vs {purple}{2} CTs",
   "retakes.center.bombsite.announcement": "Retake {green}{0}{default}: {lightred}{1} Ts{default} vs {purple}{2} CTs",
+  "retakes.bombsite.plant_location": "A bomba está plantada em {green}{0}{default}.",
   "retakes.voices.toggle": "Você tem {0} anúncios de voz!",
 
   "retakes.teams.scramble": "Terroristas venceram {green}{0}{default} rodadas consecutivas. {purple}Times estão sendo embaralhados!",

--- a/RetakesPlugin/lang/pt-PT.json
+++ b/RetakesPlugin/lang/pt-PT.json
@@ -3,14 +3,19 @@
   "retakes.no_permissions": "Não tens permissão para usar este comando.",
   "retakes.enabled": "{red}desativado{default}",
   "retakes.disabled": "{green}ativado{default}",
+  "retakes.plugin.enabled": "O plugin de retakes foi {green}ativado{default}.",
+  "retakes.plugin.disabled": "O plugin de retakes foi {red}desativado{default}.",
 
   "retakes.queue.joined": "Você foi colocado na fila de espera, aguarda a próxima ronda.",
   "retakes.queue.waiting": "As equipas estão cheias de momento com {green}{0}{default} players. Você está na fila de espera.",
+  "retakes.queue.waiting_for_players": "A aguardar jogadores: {green}{0}{default}/{green}{1}{default}. O jogo começará quando houver jogadores suficientes.",
+  "retakes.queue.minimum_players_reached": "Já há jogadores suficientes - o jogo vai começar!",
   "retakes.queue.replaced_by_vip": "Você foi substituído pelo jogador {gold}{1}{default} {green}{0}{default}.",
   "retakes.queue.vip_took_place": "Você ocupou o lugar de {green}{0}{default} no jogo por ser {gold}{1}{default}.",
 
   "retakes.bombsite.announcement": "Retake {green}{0}{default}: {lightred}{1} Ts{default} vs {purple}{2} CTs",
   "retakes.center.bombsite.announcement": "Retake {green}{0}{default}: {lightred}{1} Ts{default} vs {purple}{2} CTs",
+  "retakes.bombsite.plant_location": "A bomba está plantada em {green}{0}{default}.",
   "retakes.voices.toggle": "Você tem {0} anúncios de voz!",
 
   "retakes.teams.scramble": "Terroristas venceram {green}{0}{default} rondas consecutivas. {purple}Equipas estão sendo embaralhadas!",

--- a/RetakesPlugin/lang/ru.json
+++ b/RetakesPlugin/lang/ru.json
@@ -3,14 +3,19 @@
   "retakes.no_permissions": "У вас нет разрешения на использование этой команды.",
   "retakes.enabled": "{red}отключено{default}",
   "retakes.disabled": "{green}включено{default}",
+  "retakes.plugin.enabled": "Плагин retakes был {green}включен{default}.",
+  "retakes.plugin.disabled": "Плагин retakes был {red}выключен{default}.",
 
   "retakes.queue.joined": "Вы в очереди. Ожидайте.",
   "retakes.queue.waiting": "Сейчас играет максимальное количество игроков - {green}{0}{default}. Вы в очереди.",
+  "retakes.queue.waiting_for_players": "Ожидание игроков: {green}{0}{default}/{green}{1}{default}. Игра начнётся, когда наберётся достаточно игроков.",
+  "retakes.queue.minimum_players_reached": "Достаточно игроков присоединилось - игра начинается!",
   "retakes.queue.replaced_by_vip": "Вас заменил игрок {gold}{1}{default} {green}{0}{default}.",
   "retakes.queue.vip_took_place": "Вы заняли место {green}{0}{default} в игре, так как вы {gold}{1}{default}.",
 
   "retakes.bombsite.announcement": "Retake {green}{0}{default}: {lightred}{1} T{default} против {purple}{2} CT",
   "retakes.center.bombsite.announcement": "Retake {green}{0}{default}: {lightred}{1} T{default} против {purple}{2} CT",
+  "retakes.bombsite.plant_location": "Бомба установлена на {green}{0}{default}.",
   "retakes.voices.toggle": "У вас {0} голосовые объявления!",
 
   "retakes.teams.scramble": "Террористы выиграли {green}{0}{default} раундов подряд. {purple}Команды были перемешаны!",

--- a/RetakesPlugin/lang/sv.json
+++ b/RetakesPlugin/lang/sv.json
@@ -3,14 +3,19 @@
   "retakes.no_permissions": "Du har inte behörighet att använda detta kommando.",
   "retakes.enabled": "{red}inaktiverad{default}",
   "retakes.disabled": "{green}aktiverad{default}",
+  "retakes.plugin.enabled": "Retakes-pluginet har {green}aktiverats{default}.",
+  "retakes.plugin.disabled": "Retakes-pluginet har {red}inaktiverats{default}.",
 
   "retakes.queue.joined": "Du är placerad i kön.",
   "retakes.queue.waiting": "Matchen är just nu full med {green}{0}{default} spelare. Du är i kö.",
+  "retakes.queue.waiting_for_players": "Väntar på spelare: {green}{0}{default}/{green}{1}{default}. Spelet startar när tillräckligt många spelare har anslutit.",
+  "retakes.queue.minimum_players_reached": "Tillräckligt många spelare har anslutit - spelet startar!",
   "retakes.queue.replaced_by_vip": "Du har blivit ersatt av {gold}{1}{default}-spelaren {green}{0}{default}.",
   "retakes.queue.vip_took_place": "Du har tagit {green}{0}{default}s plats i matchen för att du är {gold}{1}{default}.",
 
   "retakes.bombsite.announcement": "Retake {green}{0}{default}: {lightred}{1} Terrorister{default} vs {purple}{2} Anti-terrorister.",
   "retakes.center.bombsite.announcement": "Retake {green}{0}{default}: {lightred}{1} Terrorister{default} vs {purple}{2} Anti-terrorister.",
+  "retakes.bombsite.plant_location": "Bomben är planterad på {green}{0}{default}.",
   "retakes.voices.toggle": "Du har {0} röstmeddelanden!",
 
   "retakes.teams.scramble": "Terroristerna har vunnit {green}{0}{default} rundor i rad. {purple}Blandar om lagen!",

--- a/RetakesPlugin/lang/tr.json
+++ b/RetakesPlugin/lang/tr.json
@@ -3,14 +3,19 @@
   "retakes.no_permissions": "Bu komutu kullanma izniniz yok.",
   "retakes.enabled": "{red}devre dışı{default}",
   "retakes.disabled": "{green}etkin{default}",
+  "retakes.plugin.enabled": "Retakes eklentisi {green}etkinleştirildi{default}.",
+  "retakes.plugin.disabled": "Retakes eklentisi {red}devre dışı bırakıldı{default}.",
 
   "retakes.queue.joined": "Bekleme sırasına alındınız.",
   "retakes.queue.waiting": "Oyun şu anda {green}{0}{default} oyuncuyla dolu. Bekleme sırasındasınız.",
+  "retakes.queue.waiting_for_players": "Oyuncular bekleniyor: {green}{0}{default}/{green}{1}{default}. Yeterli oyuncu katıldığında oyun başlayacak.",
+  "retakes.queue.minimum_players_reached": "Yeterli oyuncu katıldı - oyun başlıyor!",
   "retakes.queue.replaced_by_vip": "Yerinizi {gold}{1}{default} oyuncu {green}{0}{default} aldı.",
   "retakes.queue.vip_took_place": "Oyunda {green}{0}{default}'in yerini aldınız çünkü {gold}{1}{default} sınız.",
 
   "retakes.bombsite.announcement": "Retake {green}{0}{default}: {lightred}{1} T{default} vs {purple}{2} AT",
   "retakes.center.bombsite.announcement": "Retake {green}{0}{default}: {lightred}{1} T{default} vs {purple}{2} AT",
+  "retakes.bombsite.plant_location": "Bomba {green}{0}{default} bölgesine kuruldu.",
   "retakes.voices.toggle": "{0} sesli duyurunuz var!",
 
   "retakes.teams.scramble": "Teröristler {green}{0}{default} round arka arkaya kazandı. {purple}Takımlar karıştırılıyor!",

--- a/RetakesPlugin/lang/uz.json
+++ b/RetakesPlugin/lang/uz.json
@@ -3,14 +3,19 @@
   "retakes.no_permissions": "Sizda bu buyruqdan foydalanish huquqi yo'q.",
   "retakes.enabled": "{red}o'chirilgan{default}",
   "retakes.disabled": "{green}yoqilgan{default}",
+  "retakes.plugin.enabled": "Retakes plagini {green}yoqildi{default}.",
+  "retakes.plugin.disabled": "Retakes plagini {red}o'chirildi{default}.",
   
   "retakes.queue.joined": "Siz kutish navbatiga qo‘shildingiz.",
   "retakes.queue.waiting": "O‘yin hozirda {green}{0}{default} o‘yinchilar bilan to‘la. Siz kutish navbatidasiz.",
+  "retakes.queue.waiting_for_players": "O'yinchilar kutilmoqda: {green}{0}{default}/{green}{1}{default}. Yetarli o'yinchi qo'shilganda o'yin boshlanadi.",
+  "retakes.queue.minimum_players_reached": "Yetarli o'yinchi qo'shildi - o'yin boshlanmoqda!",
   "retakes.queue.replaced_by_vip": "Siz {gold}{1}{default} o'yinchi {green}{0}{default} bilan almashtirildingiz.",
   "retakes.queue.vip_took_place": "Siz {green}{0}{default}ning o'rniga o'yinga kirdingiz, chunki siz {gold}{1}{default} siz.",
 
   "retakes.bombsite.announcement": "Retake {green}{0}{default}: {lightred}{1} Tlar{default} va [BLUE]{2} KTlar",
   "retakes.center.bombsite.announcement": "Retake {green}{0}{default}: {lightred}{1} Tlar{default} va [BLUE]{2} KTlar",
+  "retakes.bombsite.plant_location": "Bomba {green}{0}{default} joyiga o'rnatildi.",
   "retakes.voices.toggle": "Siz ovozli e‘lonlarni {0}!",
   
   "retakes.teams.scramble": "Terrorchilar ketma-ket {green}{0}{default} raundda g‘alaba qozonishdi. {purple}Jamoalar aralashtirildi!",

--- a/RetakesPlugin/lang/vi.json
+++ b/RetakesPlugin/lang/vi.json
@@ -3,14 +3,19 @@
   "retakes.no_permissions": "Bạn không có quyền sử dụng lệnh này.",
   "retakes.enabled": "{red}đã tắt{default}",
   "retakes.disabled": "{green}đã bật{default}",
+  "retakes.plugin.enabled": "Plugin retakes đã được {green}bật{default}.",
+  "retakes.plugin.disabled": "Plugin retakes đã bị {red}tắt{default}.",
 
   "retakes.queue.joined": "Bạn đã được đưa vào hàng chờ.",
   "retakes.queue.waiting": "Trận đấu hiện đã đầy với {green}{0}{default} người chơi. Bạn đang trong hàng chờ.",
+  "retakes.queue.waiting_for_players": "Đang chờ người chơi: {green}{0}{default}/{green}{1}{default}. Trò chơi sẽ bắt đầu khi có đủ người chơi.",
+  "retakes.queue.minimum_players_reached": "Đã có đủ người chơi - trò chơi đang bắt đầu!",
   "retakes.queue.replaced_by_vip": "Bạn đã bị thay thế bởi {gold}{1}{default} {green}{0}{default}.",
   "retakes.queue.vip_took_place": "Bạn đã lấy chỗ của {green}{0}{default} trong trận vì bạn là {gold}{1}{default}.",
 
   "retakes.bombsite.announcement": "Retake {green}{0}{default}: {lightred}{1} T{default} vs {purple}{2} CT",
   "retakes.center.bombsite.announcement": "Retake {green}{0}{default}: {lightred}{1} T{default} vs {purple}{2} CT",
+  "retakes.bombsite.plant_location": "Bom được đặt tại {green}{0}{default}.",
   "retakes.voices.toggle": "Bạn đã {0} thông báo bằng giọng nói!",
 
   "retakes.teams.scramble": "T đã thắng {green}{0}{default} round liên tiếp. {purple}Đội sẽ được xáo trộn!",

--- a/RetakesPlugin/lang/zh-Hans.json
+++ b/RetakesPlugin/lang/zh-Hans.json
@@ -3,14 +3,19 @@
   "retakes.no_permissions": "您没有使用此命令的权限。",
   "retakes.enabled": "{red}已禁用{default}",
   "retakes.disabled": "{green}已启用{default}",
+  "retakes.plugin.enabled": "Retakes插件已{green}启用{default}。",
+  "retakes.plugin.disabled": "Retakes插件已{red}禁用{default}。",
 
   "retakes.queue.joined": "您已被放入等待队列。",
   "retakes.queue.waiting": "游戏当前已满，共有{green}{0}{default}名玩家。您正在等待队列中。",
+  "retakes.queue.waiting_for_players": "等待玩家中：{green}{0}{default}/{green}{1}{default}。人数足够后游戏将开始。",
+  "retakes.queue.minimum_players_reached": "人数已足够，游戏即将开始！",
   "retakes.queue.replaced_by_vip": "您已经被{gold}{1}{default}用户{green}{0}{default}插队。",
   "retakes.queue.vip_took_place": "您已经插队了{green}{0}{default}的等待位置，因为您是{gold}{1}{default}。",
 
   "retakes.bombsite.announcement": "回防{green}{0}{default}包点：{lightred}{1}名T{default}对阵{purple}{2}名CT",
   "retakes.center.bombsite.announcement": "回防{green}{0}{default}包点：{lightred}{1}名T{default}对阵{purple}{2}名CT",
+  "retakes.bombsite.plant_location": "炸弹安放在{green}{0}{default}。",
   "retakes.voices.toggle": "您已经{0}语音播报！",
 
   "retakes.teams.scramble": "T连续赢得{green}{0}{default}个回合。{purple}正在重新打乱队伍！",

--- a/RetakesPlugin/lang/zh-Hant.json
+++ b/RetakesPlugin/lang/zh-Hant.json
@@ -3,14 +3,19 @@
   "retakes.no_permissions": "您沒有使用此指令的權限。",
   "retakes.enabled": "{red}已停用{default}",
   "retakes.disabled": "{green}已啟用{default}",
+  "retakes.plugin.enabled": "Retakes插件已{green}啟用{default}。",
+  "retakes.plugin.disabled": "Retakes插件已{red}停用{default}。",
 
   "retakes.queue.joined": "您已被放入等待佇列。",
   "retakes.queue.waiting": "遊戲目前已滿，共有{green}{0}{default}名玩家。您正在等待佇列中。",
+  "retakes.queue.waiting_for_players": "等待玩家中：{green}{0}{default}/{green}{1}{default}。人數足夠後遊戲將開始。",
+  "retakes.queue.minimum_players_reached": "人數已足夠，遊戲即將開始！",
   "retakes.queue.replaced_by_vip": "您已經被{gold}{1}{default}用戶{green}{0}{default}取代。",
   "retakes.queue.vip_took_place": "您已經取代了{green}{0}{default}在遊戲中的位置，因為您是{gold}{1}{default}。",
 
   "retakes.bombsite.announcement": "回防{green}{0}{default}炸彈點：{lightred}{1}名恐怖份子{default}對陣{purple}{2}名反恐小组",
   "retakes.center.bombsite.announcement": "回防{green}{0}{default}炸彈點：{lightred}{1}名恐怖份子{default}對陣{purple}{2}名反恐小组",
+  "retakes.bombsite.plant_location": "炸彈安放在{green}{0}{default}。",
   "retakes.voices.toggle": "您已經{0}語音播報！",
 
   "retakes.teams.scramble": "T連續贏得{green}{0}{default}個回合。{purple}正在重新打亂隊伍！",

--- a/RetakesPluginShared/RetakesPluginShared.csproj
+++ b/RetakesPluginShared/RetakesPluginShared.csproj
@@ -2,18 +2,19 @@
     <PropertyGroup>
         <PackageId>RetakesPluginShared</PackageId>
         <Title>RetakesPluginShared</Title>
-        <Description>
-            This library is made to run alongside https://github.com/b3none/cs2-retakes
-        </Description>
+        <Description>This library is made to run alongside https://github.com/b3none/cs2-retakes</Description>
         <Authors>B3none</Authors>
-        
+
         <Version>2.0.0</Version>
-        
-        <TargetFramework>net8.0</TargetFramework>
+
+        <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <RootNamespace>RetakesPluginShared</RootNamespace>
-        <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+        <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
+        <OutputPath>..\build-output\addons\counterstrikesharp\shared\RetakesPluginShared\</OutputPath>
+        <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+        <DebugType>portable</DebugType>
 
         <PackageReadmeFile>README.md</PackageReadmeFile>
         <PackageLicenseFile>LICENSE</PackageLicenseFile>


### PR DESCRIPTION
This PR works through the open issue backlog and folds in @wiruwiru's PR #280 (cherry-picked with original authorship).

## Issues addressed

### Fixes #186 — server crash / round-restart loop when players spam team selection on map change
- Every `ChangeTeam` / `SwitchTeam` call now goes through `PlayerHelper.TryChangeTeam` / `TrySwitchTeam`, which validate the entity (valid + connected) and swallow the `Entity is not valid` throw that crashed servers.
- `GameRulesHelper.RestartGame()` no longer throws when game rules aren't available yet (map transition window).
- The "no active players → restart game" path (the restart loop from the issue) is debounced with a 3 second cooldown.

### Fixes #78 — activate/deactivate the plugin via convar
New fake convar **`retakes_enabled`** (default `1`).
- `retakes_enabled 0`: all retakes logic stops, queues are cleared, and `retakes_unload.cfg` is executed so normal game convars are restored (nade practice actually works).
- `retakes_enabled 1`: re-execs `retakes.cfg`, rebuilds the queues from whoever is on a team, and restarts the game.

### Fixes #109, fixes #124 — minimum players to start
New **`GameSettings.MinimumPlayers`** (default `0` = off, set to `2` to enable). Below the threshold the server parks in a paused warmup and announces progress; the game starts automatically once enough humans have joined. An empty server idles cleanly in warmup instead of cycling rounds.

### Fixes #37 — announce the plant location to Ts
New **`MapConfigSettings.EnablePlantLocationAnnouncement`** (default `false`). Planter spawns support an optional **`PlantLocation`** callout string in the map config (e.g. `"Short"`), settable in-game via `!add T Y Short`. On plant, Terrorists (only) see "The bomb has been planted for Short.", falling back to the bombsite letter when no callout is configured. Note: with manual planting (`IsAutoPlantEnabled=false`) the announcement reflects the assigned planter spawn, not wherever the planter wandered to.

### Fixes #101 — reset config when the plugin is unloaded
A new `cfg/cs2-retakes/retakes_unload.cfg` (created at map start so owners can customise it up front) is executed on plugin unload, restoring every convar `retakes.cfg` changes.

### Fixes #224 — team selection on connect
New **`QueueSettings.ShouldAutoJoinGame`** (default `false`): connecting players go straight into the game (warmup) or the join queue (mid-round) with no team menu — the feature-flag approach discussed on the issue.

## PR #280 by @wiruwiru (cherry-picked, conflicts with master resolved)
- `chore: migrate from .NET 8.0 to 10.0 and streamline build process` — also bumps CounterStrikeSharp to 1.0.369 / `MinimumApiVersion(369)`.
- `fix: Solution to the ten-second warning at the start of each round.` — `mp_roundtime_defuse 0.25 → 1.25` (thanks @DPL^V for finding it).
- On top of that, existing installs are migrated automatically: if `retakes.cfg` still contains the exact old default `mp_roundtime_defuse 0.25` it is rewritten to `1.25` at map start (custom values untouched).

## Backwards compatibility
Upgrading is drop-in for non-technical server owners:
- Every new config key defaults to **off** — an old `retakes_config.json` behaves exactly as before, with no warnings (ConfigVersion unchanged).
- New chat strings only appear behind opt-in features; all 19 bundled languages include the new keys.
- **The one requirement: servers must be on CounterStrikeSharp v369+ and the .NET 10 runtime that recent CSSharp ships with (from PR #280).**

## Other
- All GitHub Actions in both workflows (`plugin-build.yml`, `formatting.yml`) updated to their current Node 24 majors (`checkout@v7`, `setup-dotnet@v6`, `upload-artifact@v7`, `download-artifact@v8`, `action-gh-release@v3`), clearing the Node.js 20 deprecation warnings.
- Also fixes the "nobody can join after map change, rounds restart forever" reports from Discord (same root cause as #186).
- Version bumped to 3.1.0.
- README documents all new options, the convar, and both cfg files.
- Not addressed here: #171 (best as a standalone plugin, per earlier comment) and #113 (needs investigation into `sv_skirmish_id` engine behaviour, not a code fix).

Every change was built against net10.0/CSSharp 1.0.369 and reviewed for game-flow correctness, API usage, backwards compatibility, localization and issue coverage.

