### PR TITLE
Fix players stuck in death cam after auto-joining during warmup

### DIFF
--- a/RetakesPlugin/Managers/GameManager.cs
+++ b/RetakesPlugin/Managers/GameManager.cs
@@ -49,10 +49,16 @@ public class GameManager
     {
         var alreadyWaiting = IsWaitingForPlayers;
 
-        // Always re-assert the paused warmup so the hold recovers from an
-        // unexpected round restart happening while we were already waiting.
         IsWaitingForPlayers = true;
-        Server.ExecuteCommand("mp_warmup_start");
+
+        // Re-assert the warmup so the hold recovers from an unexpected round restart
+        // happening while we were already waiting, but don't restart one we are
+        // already in, that would needlessly respawn everyone.
+        if (!(GameRulesHelper.GetGameRulesOrNull()?.WarmupPeriod ?? false))
+        {
+            Server.ExecuteCommand("mp_warmup_start");
+        }
+
         Server.ExecuteCommand("mp_warmup_pausetimer 1");
 
         if (!alreadyWaiting)
@@ -78,6 +84,14 @@ public class GameManager
     {
         if (!IsWaitingForPlayers)
         {
+            // Take the hold as soon as we are short on players during a warmup,
+            // otherwise the warmup timer runs out, ends the round, and only then
+            // does round pre-start bounce us back into a paused warmup.
+            if (ShouldWaitForPlayers() && (GameRulesHelper.GetGameRulesOrNull()?.WarmupPeriod ?? false))
+            {
+                StartWaitingForPlayers();
+            }
+
             return;
         }
 

--- a/RetakesPlugin/Utils/PlayerHelper.cs
+++ b/RetakesPlugin/Utils/PlayerHelper.cs
@@ -31,6 +31,23 @@ public static class PlayerHelper
         try
         {
             player.ChangeTeam(team);
+
+            // ChangeTeam kills the player. During warmup nothing brings them back:
+            // retakes.cfg disables mp_respawn_on_death_ct/t and the warmup timer is
+            // paused while waiting for players, so there is no round restart either.
+            // Without this they sit in death cam until they switch team by hand.
+            if (team is CsTeam.Terrorist or CsTeam.CounterTerrorist
+                && (GameRulesHelper.GetGameRulesOrNull()?.WarmupPeriod ?? false))
+            {
+                Server.NextFrame(() =>
+                {
+                    if (IsValid(player) && IsConnected(player) && !player.PawnIsAlive)
+                    {
+                        player.Respawn();
+                    }
+                });
+            }
+
             return true;
         }
         catch (Exception ex)


### PR DESCRIPTION
## The bug

Join a server that is waiting for players and you end up watching death cam until you switch team by hand.

`TryChangeTeam` calls `ChangeTeam`, which kills the pawn. During warmup nothing brings it back:

- `retakes.cfg` sets `mp_respawn_on_death_ct 0` / `mp_respawn_on_death_t 0`
- the warmup timer is paused (`mp_warmup_pausetimer 1`) while waiting for players, so no round restart spawns anyone either

So every path that seats a player (auto-join, team balance, `!guns`-style re-seats) leaves them dead with no way out.

## The fix

**`PlayerHelper.TryChangeTeam`** — respawn on the next frame after a `ChangeTeam` to T/CT while `WarmupPeriod` is set. Every path that seats a player routes through this one function, so the guard lives there rather than in each caller.

**`GameManager`** — two related warmup-hold fixes:

- `CheckWaitingForPlayers` now takes the hold as soon as the server is short on players *during* a warmup. Previously the warmup timer was left to expire, end the round, and only then bounce back into a paused warmup on round pre-start — a visible round of nothing.
- `StartWaitingForPlayers` no longer fires `mp_warmup_start` when a warmup is already running. Restarting one respawns everybody for no reason; the `mp_warmup_pausetimer 1` re-assert is still unconditional, so the hold still recovers from an unexpected round restart.

## Testing

Built clean (`dotnet build -c Release`, 0 warnings). Verified in game: joining an empty/under-populated server now spawns you alive in warmup instead of death cam, and the hold engages immediately rather than after a wasted warmup expiry.